### PR TITLE
SCC-34 Query Assembler

### DIFF
--- a/include/SCC/query_assembler.h
+++ b/include/SCC/query_assembler.h
@@ -19,8 +19,9 @@ public:
 
 private:
   std::shared_ptr<Node> ast_;
-  std::ofstream &out_ = config.WriteCypher();
+  std::ofstream& out_ = config.WriteCypher();
   int constraint_counter = 0;
+  int relationship_counter = 0;
 
   void TranslateProgram(std::shared_ptr<Node> node);
   void TranslateQuery(std::shared_ptr<Node> node);
@@ -34,18 +35,23 @@ private:
   void TranslateDropDatabase(std::shared_ptr<Node> node);
   void TranslateDropTable(std::shared_ptr<Node> node);
 
+  void TranslateAlterTableActionAdd(std::shared_ptr<Node> action_node,
+                                    std::string& table_name);
+  void TranslateAlterTableActionDrop(std::shared_ptr<Node> action_node,
+                                     std::string& table_name);
+
   std::vector<StdProperty> TranslateListOfColumnDefinitions(
       std::shared_ptr<Node> node);
   StdProperty TranslateColumnDefinition(std::shared_ptr<Node> node);
 
-  void TranslateTableConstraint(std::shared_ptr<Node> node,
-                                std::string table_name);
+  void TranslateListOfTableConstraints(std::shared_ptr<Node> node,
+                                       std::string& table_name);
   std::shared_ptr<Node> FindConstraint(std::shared_ptr<Node> node);
 
   void TranslateDropObject(std::shared_ptr<Node> node,
-                           std::string table_name);
+                           std::string& table_name);
   void TranslateListOfDropObjects(std::shared_ptr<Node> node,
-                                  std::string table_name);
+                                  std::string& table_name);
 
   void TranslateInsert(std::shared_ptr<Node> node);
   void TranslateDelete(std::shared_ptr<Node> node);
@@ -59,7 +65,6 @@ private:
       std::string& table_name);
   void TranslateForeignKey(
       std::shared_ptr<Node> key,
-      std::string& constraint_name,
       std::string& table_name);
   void CreateUniqueNodePropertyConstraint(
       const std::string& constraint_name,
@@ -69,9 +74,13 @@ private:
       const std::string& constraint_name,
       const std::string& LabelName,
       const std::string& property);
+  void CreateRelationship(const std::string& label_name,
+                          const std::string& ref_label_name);
+  void RemoveProperties(const std::string& label_name,
+                        const std::vector<std::string>& properties);
 
-  std::vector<std::string> GetListOfProperties(std::shared_ptr<Node> node);
-  std::vector<std::string> GetListOfNames(std::shared_ptr<Node> node);
+  std::vector<std::string> GetListOf(std::shared_ptr<Node> node,
+                                     StatementType type);
 
   std::string TranslateName(std::shared_ptr<Node> node);
   std::string TranslateIdentifiers(std::shared_ptr<Node> node);

--- a/include/SCC/query_assembler.h
+++ b/include/SCC/query_assembler.h
@@ -1,1 +1,79 @@
 #pragma once
+
+#include "SCC/log.h"
+#include "SCC/config.h"
+#include "SCC/ast.h"
+#include "SCC/syntax_analyzer.h"
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <algorithm>
+#include <tuple>
+
+// Column as property with standard data
+using StdProperty = std::tuple<std::string, std::string>;
+
+class QueryAssembler {
+public:
+  void Translate(std::shared_ptr<Node> AST);
+
+private:
+  std::shared_ptr<Node> ast_;
+  std::ofstream &out_ = config.WriteCypher();
+  int constraint_counter = 0;
+
+  void TranslateProgram(std::shared_ptr<Node> node);
+  void TranslateQuery(std::shared_ptr<Node> node);
+
+  void TranslateDDLStatement(std::shared_ptr<Node> node);
+  void TranslateDMLStatement(std::shared_ptr<Node> node);
+
+  void TranslateCreateDatabase(std::shared_ptr<Node> node);
+  void TranslateCreateTable(std::shared_ptr<Node> node);
+  void TranslateAlterTable(std::shared_ptr<Node> node);
+  void TranslateDropDatabase(std::shared_ptr<Node> node);
+  void TranslateDropTable(std::shared_ptr<Node> node);
+
+  std::vector<StdProperty> TranslateListOfColumnDefinitions(
+      std::shared_ptr<Node> node);
+  StdProperty TranslateColumnDefinition(std::shared_ptr<Node> node);
+
+  void TranslateTableConstraint(std::shared_ptr<Node> node,
+                                std::string table_name);
+  std::shared_ptr<Node> FindConstraint(std::shared_ptr<Node> node);
+
+  void TranslateDropObject(std::shared_ptr<Node> node,
+                           std::string table_name);
+  void TranslateListOfDropObjects(std::shared_ptr<Node> node,
+                                  std::string table_name);
+
+  void TranslateInsert(std::shared_ptr<Node> node);
+  void TranslateDelete(std::shared_ptr<Node> node);
+  void TranslateUpdate(std::shared_ptr<Node> node);
+
+  // Basic statements
+
+  void TranslatePrimaryKey(
+      std::shared_ptr<Node> key,
+      std::string& constraint_name,
+      std::string& table_name);
+  void TranslateForeignKey(
+      std::shared_ptr<Node> key,
+      std::string& constraint_name,
+      std::string& table_name);
+  void CreateUniqueNodePropertyConstraint(
+      const std::string& constraint_name,
+      const std::string& LabelName,
+      const std::vector<std::string>& properties);
+  void CreateNodePropertyExistenceConstraint(
+      const std::string& constraint_name,
+      const std::string& LabelName,
+      const std::string& property);
+
+  std::vector<std::string> GetListOfProperties(std::shared_ptr<Node> node);
+  std::vector<std::string> GetListOfNames(std::shared_ptr<Node> node);
+
+  std::string TranslateName(std::shared_ptr<Node> node);
+  std::string TranslateIdentifiers(std::shared_ptr<Node> node);
+  std::string TranslateIdentifier(std::shared_ptr<Node> node);
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,8 +14,8 @@ int main(int argc, char* argv[]) {
   std::shared_ptr<Node> AST =
       syntax_analyzer.Analyze(tokenizer.get_tokens_array());
 
-//  QueryAssembler query_assembler;
-//  query_assembler.Translate(AST);
+  QueryAssembler query_assembler;
+  query_assembler.Translate(AST);
 
   config.CloseOutputFile();
   config.CloseInputFile();

--- a/src/query_assembler.cpp
+++ b/src/query_assembler.cpp
@@ -55,11 +55,14 @@ void QueryAssembler::TranslateQuery(std::shared_ptr<Node> node) {
 
   auto data_language = node->get_child(0);
   switch (data_language->get_st_type()) {
-    case StatementType::ddlStatement:this->TranslateDDLStatement(data_language);
+    case StatementType::ddlStatement:
+      this->TranslateDDLStatement(data_language);
       break;
-    case StatementType::dmlStatement:this->TranslateDMLStatement(data_language);
+    case StatementType::dmlStatement:
+      this->TranslateDMLStatement(data_language);
       break;
-    default:LOG(ERROR, "unknown query data language");
+    default:
+      LOG(ERROR, "unknown query data language");
       exit(EXIT_FAILURE);
   }
 }
@@ -78,14 +81,17 @@ void QueryAssembler::TranslateDDLStatement(std::shared_ptr<Node> node) {
     case StatementType::createTableStatement:
       this->TranslateCreateTable(statement);
       break;
-    case StatementType::alterTableStatement:this->TranslateAlterTable(statement);
+    case StatementType::alterTableStatement:
+      this->TranslateAlterTable(statement);
       break;
     case StatementType::dropDatabaseStatement:
       this->TranslateDropDatabase(statement);
       break;
-    case StatementType::dropTableStatement:this->TranslateDropTable(statement);
+    case StatementType::dropTableStatement:
+      this->TranslateDropTable(statement);
       break;
-    default:LOG(ERROR, "unknown DDL statement");
+    default:
+      LOG(ERROR, "unknown DDL statement");
       exit(EXIT_FAILURE);
   }
 }
@@ -96,13 +102,17 @@ void QueryAssembler::TranslateDMLStatement(std::shared_ptr<Node> node) {
 
   auto statement = node->get_child(0);
   switch (statement->get_st_type()) {
-    case StatementType::insertStatement:this->TranslateInsert(statement);
+    case StatementType::insertStatement:
+      this->TranslateInsert(statement);
       break;
-    case StatementType::deleteStatement:this->TranslateDelete(statement);
+    case StatementType::deleteStatement:
+      this->TranslateDelete(statement);
       break;
-    case StatementType::updateStatement:this->TranslateUpdate(statement);
+    case StatementType::updateStatement:
+      this->TranslateUpdate(statement);
       break;
-    default:LOG(ERROR, "unknown DML statement");
+    default:
+      LOG(ERROR, "unknown DML statement");
       exit(EXIT_FAILURE);
   }
 }
@@ -157,11 +167,15 @@ void QueryAssembler::TranslateCreateTable(std::shared_ptr<Node> node) {
       exit(EXIT_FAILURE);
     }
 
+    if (comma->get_children_amount() == 0) {
+      LOG(ERROR, "invalid table definition: comma without children");
+      exit(EXIT_FAILURE);
+    }
     if (comma->get_child(0)->get_st_type()
         == StatementType::columnDefinition) {
       std::vector<StdProperty> other_props =
           this->TranslateListOfColumnDefinitions(comma);
-      for (auto &i: other_props) {
+      for (auto& i: other_props) {
         out_ << ", " << std::get<0>(i) << ": " << std::get<1>(i);
       }
     }
@@ -173,7 +187,7 @@ void QueryAssembler::TranslateCreateTable(std::shared_ptr<Node> node) {
   if (table_definition->get_children_amount() > 1) {
     auto constraints = this->FindConstraint(table_definition->get_child(1));
     if (constraints != nullptr) {
-      this->TranslateTableConstraint(constraints, table_name);
+      this->TranslateListOfTableConstraints(constraints, table_name);
     }
   }
 }
@@ -192,200 +206,242 @@ void QueryAssembler::TranslateAlterTable(std::shared_ptr<Node> node) {
 
   auto action_node = node->get_child(1);
   if (action_node->get_st_type() == StatementType::alterActionADD) {
-    if (action_node->get_children_amount() < 1) {
-      LOG(ERROR, "alter table ADD without content");
-      exit(EXIT_FAILURE);
-    }
-    auto table_definition = action_node->get_child(0);
-
-    if (table_definition->get_children_amount() < 1) {
-      LOG(ERROR, "alter table ADD action without arguments");
-      exit(EXIT_FAILURE);
-    }
-    auto first_argument = table_definition->get_child(0);
-
-    bool is_constraint_first = true;
-
-    // Get column definitions
-    if (first_argument->get_st_type() == StatementType::columnDefinition) {
-      is_constraint_first = false;
-
-      out_ << "MATCH (n:" << table_name << ")\n";
-      out_ << "SET ";
-
-      StdProperty first_prop =
-          this->TranslateColumnDefinition(first_argument);
-      out_ << "n." << std::get<0>(first_prop)
-           << " = " << std::get<1>(first_prop);
-
-      if (table_definition->get_children_amount() > 1) {
-        auto comma = table_definition->get_child(1);
-        if (comma->get_st_type() != StatementType::delimiter_comma) {
-          LOG(ERROR, "delimiter between column definitions is not a comma");
-          exit(EXIT_FAILURE);
-        }
-
-        if (comma->get_child(0)->get_st_type()
-            == StatementType::columnDefinition) {
-          std::vector<StdProperty> other_props =
-              this->TranslateListOfColumnDefinitions(comma);
-
-          for (auto& i : other_props) {
-            out_ << ", n." << std::get<0>(i)
-                 << " = " << std::get<1>(i);
-          }
-        }
-      }
-
-      out_ << ";\n" << std::endl;
-    }
-
-    // Get table constraints
-    if (is_constraint_first) {
-      this->TranslateTableConstraint(table_definition, table_name);
-    } else {
-      auto constraints =
-          this->FindConstraint(table_definition->get_child(1));
-      if (constraints != nullptr) {
-        this->TranslateTableConstraint(constraints, table_name);
-      }
-    }
+    this->TranslateAlterTableActionAdd(action_node, table_name);
   } else if (action_node->get_st_type() == StatementType::alterActionDROP) {
-    if (action_node->get_children_amount() < 1) {
-      LOG(ERROR, "alter table DROP without content");
-      exit(EXIT_FAILURE);
-    }
-    auto drop_list_def = action_node->get_child(0);
-
-    if (drop_list_def->get_children_amount() < 1) {
-      LOG(ERROR, "alter table DROP without arguments");
-    }
-    auto object = drop_list_def->get_child(0);
-
-    this->TranslateDropObject(object, table_name);
-
-    if (drop_list_def->get_children_amount() > 1) {
-      auto other_objects = drop_list_def->get_child(1);
-      this->TranslateListOfDropObjects(other_objects, table_name);
-    }
+    this->TranslateAlterTableActionDrop(action_node, table_name);
   }
 }
 void QueryAssembler::TranslateDropDatabase(std::shared_ptr<Node> node) {
   if (node->get_children_amount() == 0) {
     LOG(ERROR, "database name is missed");
-    return;
+    exit(EXIT_FAILURE);
   }
 
-  std::vector<std::string> db_names;
-  db_names.push_back(this->TranslateName(node->get_child(0)));
+  out_ << "DROP DATABASE "
+       << this->TranslateName(node->get_child(0))
+       << ";\n" << std::endl;
 
   if (node->get_children_amount() > 1) {
     std::vector<std::string> other_db_names =
-        this->GetListOfNames(node->get_child(1));
-    db_names.insert(db_names.end(),
-                    other_db_names.begin(),
-                    other_db_names.end());
-  }
-
-  for (auto &i: db_names) {
-    out_ << "DROP DATABASE " << i << ";\n" << std::endl;
+        this->GetListOf(node->get_child(1), StatementType::name);
+    for (auto& i: other_db_names) {
+      out_ << "DROP DATABASE " << i << ";\n" << std::endl;
+    }
   }
 }
 void QueryAssembler::TranslateDropTable(std::shared_ptr<Node> node) {
   if (node->get_children_amount() == 0) {
     LOG(ERROR, "table name is missed");
-    return;
+    exit(EXIT_FAILURE);
   }
 
   std::vector<std::string> table_names;
-  table_names.push_back(this->TranslateName(node->get_child(0)));
+  out_ << "MATCH (x:"
+       << this->TranslateName(node->get_child(0))
+       << ") DELETE x;\n" << std::endl;
 
   if (node->get_children_amount() > 1) {
     std::vector<std::string> other_table_names =
-        this->GetListOfNames(node->get_child(1));
-    table_names.insert(table_names.end(),
-                       other_table_names.begin(),
-                       other_table_names.end());
+        this->GetListOf(node->get_child(1), StatementType::name);
+    for (auto& i: other_table_names) {
+      out_ << "MATCH (x:" << i << ") DELETE x;\n" << std::endl;
+    }
+  }
+}
+
+void QueryAssembler::TranslateAlterTableActionAdd(
+    std::shared_ptr<Node> action_node,
+    std::string& table_name) {
+  if (action_node->get_children_amount() == 0) {
+    LOG(ERROR, "alter table ADD without content");
+    exit(EXIT_FAILURE);
+  }
+  auto table_definition = action_node->get_child(0);
+
+  if (table_definition->get_children_amount() == 0) {
+    LOG(ERROR, "alter table ADD action without arguments");
+    exit(EXIT_FAILURE);
+  }
+  auto first_argument = table_definition->get_child(0);
+
+  bool is_constraint_first = true;
+
+  // Get column definitions
+  if (first_argument->get_st_type() == StatementType::columnDefinition) {
+    is_constraint_first = false;
+
+    out_ << "MATCH (n:" << table_name << ")\n";
+    out_ << "SET ";
+
+    StdProperty first_prop =
+        this->TranslateColumnDefinition(first_argument);
+    out_ << "n." << std::get<0>(first_prop)
+         << " = " << std::get<1>(first_prop);
+
+    if (table_definition->get_children_amount() > 1) {
+      auto comma = table_definition->get_child(1);
+      if (comma->get_st_type() != StatementType::delimiter_comma) {
+        LOG(ERROR, "delimiter between column definitions is not a comma");
+        exit(EXIT_FAILURE);
+      }
+
+      if (comma->get_child(0)->get_st_type()
+          == StatementType::columnDefinition) {
+        std::vector<StdProperty> other_props =
+            this->TranslateListOfColumnDefinitions(comma);
+
+        for (auto& i: other_props) {
+          out_ << ", n." << std::get<0>(i)
+               << " = " << std::get<1>(i);
+        }
+      }
+    }
+
+    out_ << ";\n" << std::endl;
   }
 
-  for (auto &i: table_names) {
-    out_ << "MATCH (x:" << i << ") DELETE x;\n" << std::endl;
+  // Get table constraints
+  if (is_constraint_first) {
+    this->TranslateListOfTableConstraints(table_definition, table_name);
+  } else {
+    auto constraints =
+        this->FindConstraint(table_definition->get_child(1));
+    if (constraints != nullptr) {
+      this->TranslateListOfTableConstraints(constraints, table_name);
+    }
+  }
+}
+void QueryAssembler::TranslateAlterTableActionDrop(
+    std::shared_ptr<Node> action_node,
+    std::string& table_name) {
+  if (action_node->get_children_amount() == 0) {
+    LOG(ERROR, "alter table DROP without content");
+    exit(EXIT_FAILURE);
+  }
+  auto drop_list_def = action_node->get_child(0);
+
+  if (drop_list_def->get_children_amount() == 0) {
+    LOG(ERROR, "alter table DROP without arguments");
+  }
+  auto object = drop_list_def->get_child(0);
+
+  this->TranslateDropObject(object, table_name);
+
+  if (drop_list_def->get_children_amount() > 1) {
+    auto other_objects = drop_list_def->get_child(1);
+    this->TranslateListOfDropObjects(other_objects, table_name);
   }
 }
 
 std::vector<StdProperty> QueryAssembler::TranslateListOfColumnDefinitions(
     std::shared_ptr<Node> node) {
-  auto first = node->get_child(0);
-  if (first->get_st_type() != StatementType::columnDefinition) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "invalid list of column definitions: comma without children");
+    exit(EXIT_FAILURE);
+  }
+  auto argument = node->get_child(0);
+  if (argument->get_st_type() != StatementType::columnDefinition) {
     LOG(TRACE, "list of column definitions is ended");
     return {};
   }
 
-  std::vector<StdProperty> list_of_cols;
-  list_of_cols.push_back(this->TranslateColumnDefinition(first));
+  std::vector<StdProperty> column_definitions;
+  column_definitions.push_back(this->TranslateColumnDefinition(argument));
   if (node->get_children_amount() > 1) {
     auto comma = node->get_child(1);
     if ((comma->get_child(0))->get_st_type()
         == StatementType::columnDefinition) {
       std::vector<StdProperty> other_cols =
           this->TranslateListOfColumnDefinitions(node->get_child(1));
-
-      list_of_cols.insert(list_of_cols.end(),
-                          other_cols.begin(),
-                          other_cols.end());
+      column_definitions.insert(column_definitions.end(),
+                                other_cols.begin(),
+                                other_cols.end());
     }
   }
 
-  return list_of_cols;
+  return column_definitions;
 }
 StdProperty QueryAssembler::TranslateColumnDefinition(
     std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "empty column definition");
+    exit(EXIT_FAILURE);
+  }
   std::string column_name = this->TranslateIdentifier(node->get_child(0));
 
-  auto datatype_node = node->get_child(1);
-  StatementType datatype = datatype_node->get_st_type();
+  if (node->get_children_amount() == 1) {
+    LOG(ERROR, "invalid column definition: datatype is missed");
+    exit(EXIT_FAILURE);
+  }
+  StatementType datatype = node->get_child(1)->get_st_type();
 
   std::string datatype_str;
   switch (datatype) {
-    case StatementType::SQL_int:datatype_str = "0";
+    case StatementType::SQL_int:
+      datatype_str = "0";
       break;
-    case StatementType::SQL_float:datatype_str = "0.0";
+    case StatementType::SQL_float:
+      datatype_str = "0.0";
       break;
     case StatementType::SQL_char:
-    case StatementType::SQL_varchar:datatype_str = "\"\"";
+    case StatementType::SQL_varchar:
+      datatype_str = "\"\"";
       break;
-    default:LOG(ERROR, "unknown SQL datatype");
-      datatype_str = "null";
+    default:
+      LOG(ERROR, "unknown SQL datatype");
+      exit(EXIT_FAILURE);
   }
 
   return std::tie(column_name, datatype_str);
 }
 
-void QueryAssembler::TranslateTableConstraint(std::shared_ptr<Node> node,
-                                              std::string table_name) {
-  int child_with_key = 0;
-  std::string constraint_name;
+void QueryAssembler::TranslateListOfTableConstraints(std::shared_ptr<Node> node,
+                                                     std::string& table_name) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR,
+        "invalid list of table constraints: comma without children");
+    exit(EXIT_FAILURE);
+  }
 
-  auto constraint_serv_node = node->get_child(0);
-  if (constraint_serv_node->get_children_amount() > 1) {
-    child_with_key++;
-    auto constraint_kw = constraint_serv_node->get_child(0);
+  auto constraint = node->get_child(0);
+  if (constraint->get_children_amount() == 0) {
+    LOG(ERROR, "empty table constraint");
+    exit(EXIT_FAILURE);
+  }
+
+  // Create new constraint name if necessary
+  size_t key_node_number = 0;
+  std::string constraint_name;
+  if (constraint->get_children_amount() > 1) {
+    key_node_number++;
+
+    auto constraint_kw = constraint->get_child(0);
+    if (constraint_kw->get_st_type() != StatementType::kw_constraint
+        || constraint_kw->get_children_amount() == 0) {
+      LOG(ERROR, "invalid CONSTRAINT key word node");
+      exit(EXIT_FAILURE);
+    }
+
     constraint_name +=
         this->TranslateIdentifier(constraint_kw->get_child(0));
   } else {
-    constraint_name = "constraint";
+    constraint_name = table_name + "_constraint";
   }
 
-  // Translate constraint
-  auto key = constraint_serv_node->get_child(child_with_key);
+  // Translate constraint definition
+  if (constraint->get_children_amount() < key_node_number) {
+    LOG(ERROR, "table constraint definition is missed");
+    exit(EXIT_FAILURE);
+  }
+  auto key = constraint->get_child(key_node_number);
   if (key->get_st_type() == StatementType::primaryKey) {
     this->TranslatePrimaryKey(key, constraint_name, table_name);
   } else if (key->get_st_type() == StatementType::foreignKey) {
-    this->TranslateForeignKey(key, constraint_name, table_name);
+    this->TranslateForeignKey(key, table_name);
   }
 
   if (node->get_children_amount() > 1) {
-    this->TranslateTableConstraint(
+    this->TranslateListOfTableConstraints(
         node->get_child(1),
         table_name);
   }
@@ -393,6 +449,9 @@ void QueryAssembler::TranslateTableConstraint(std::shared_ptr<Node> node,
 std::shared_ptr<Node> QueryAssembler::FindConstraint(
     std::shared_ptr<Node> node) {
   std::shared_ptr<Node> constraints = nullptr;
+  if (node->get_children_amount() == 0) {
+    return constraints;
+  }
 
   auto left = node->get_child(0);
   if (left->get_st_type() == StatementType::tableConstraint) {
@@ -406,42 +465,55 @@ std::shared_ptr<Node> QueryAssembler::FindConstraint(
   return constraints;
 }
 
-void QueryAssembler::TranslateDropObject(
-    std::shared_ptr<Node> node,
-    std::string table_name) {
-  StatementType drop_type = node->get_st_type();
-  if (drop_type == StatementType::dropColumn) {
-    std::vector<std::string> properties = this->GetListOfProperties(node);
-
-    out_ << "MATCH (n:" << table_name << ")\n";
-    out_ << "SET ";
-    for (size_t i = 0; i < properties.size(); i++) {
-      out_ << "n." << properties[i] << " = null";
-      if (i + 1 != properties.size()) {
-        out_ << ", ";
-      }
-    }
-    out_ << ";\n" << std::endl;
-  } else if (drop_type == StatementType::dropConstraint) {
-    std::vector<std::string> constraints = this->GetListOfProperties(node);
-    for (auto &i: constraints) {
-      out_ << "DROP CONSTRAINT " << i;
-      out_ << ";\n" << std::endl;
-    }
-  } else {
-    LOG(ERROR, "unknown type for the drop object");
-    return;
-  }
-}
 void QueryAssembler::TranslateListOfDropObjects(
     std::shared_ptr<Node> node,
-    std::string table_name) {
-  auto object = node->get_child(0);
-  this->TranslateDropObject(object, table_name);
+    std::string& table_name) {
+  if (node->get_st_type() != StatementType::dropList) {
+    LOG(ERROR, "invalid statement type for the dropList");
+    exit(EXIT_FAILURE);
+  }
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "invalid dropList without children");
+    exit(EXIT_FAILURE);
+  }
+
+  this->TranslateDropObject(node->get_child(0), table_name);
 
   if (node->get_children_amount() > 1) {
     auto other_objects = node->get_child(1);
     this->TranslateListOfDropObjects(other_objects, table_name);
+  }
+}
+void QueryAssembler::TranslateDropObject(
+    std::shared_ptr<Node> node,
+    std::string& table_name) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "invalid drop object without children");
+    exit(EXIT_FAILURE);
+  }
+  std::string argument = this->TranslateIdentifier(node->get_child(0));
+  std::vector<std::string> other_arguments;
+  if (node->get_children_amount() > 1) {
+    other_arguments =
+        this->GetListOf(node->get_child(1), StatementType::identifier);
+  }
+
+  if (node->get_st_type() == StatementType::dropColumn) {
+    out_ << "MATCH (n:" << table_name << ")\n";
+    out_ << "SET " << argument;
+    for (auto& i: other_arguments) {
+      out_ << ", n." << i << " = null";
+    }
+    out_ << ";\n" << std::endl;
+  } else if (node->get_st_type() == StatementType::dropConstraint) {
+    out_ << "DROP CONSTRAINT " << argument << ";\n" << std::endl;
+    for (auto& i: other_arguments) {
+      out_ << "DROP CONSTRAINT " << i;
+      out_ << ";\n" << std::endl;
+    }
+  } else {
+    LOG(ERROR, "unknown type of the drop object");
+    exit(EXIT_FAILURE);
   }
 }
 
@@ -453,17 +525,25 @@ void QueryAssembler::TranslateUpdate(std::shared_ptr<Node> node) {}
 
 void QueryAssembler::TranslatePrimaryKey(
     std::shared_ptr<Node> key,
-    std::string &constraint_name,
-    std::string &table_name) {
+    std::string& constraint_name,
+    std::string& table_name) {
+  if (key->get_st_type() != StatementType::primaryKey) {
+    LOG(ERROR, "incorrect type for primaryKey node");
+    exit(EXIT_FAILURE);
+  }
+  if (key->get_children_amount() == 0) {
+    LOG(ERROR, "PRIMARY KEY definition is missed");
+    exit(EXIT_FAILURE);
+  }
+
   std::vector<std::string> properties;
   properties.push_back(this->TranslateIdentifier(key->get_child(0)));
-
   if (key->get_children_amount() > 1) {
-    std::vector<std::string> other_prop =
-        this->GetListOfProperties(key->get_child(1));
+    std::vector<std::string> other_properties =
+        this->GetListOf(key->get_child(1), StatementType::identifier);
     properties.insert(properties.end(),
-                      other_prop.begin(),
-                      other_prop.end());
+                      other_properties.begin(),
+                      other_properties.end());
   }
 
   this->CreateUniqueNodePropertyConstraint(
@@ -471,7 +551,7 @@ void QueryAssembler::TranslatePrimaryKey(
       table_name,
       properties
   );
-  for (auto &i: properties) {
+  for (auto& i: properties) {
     this->CreateNodePropertyExistenceConstraint(
         (constraint_name + "_" + std::to_string(constraint_counter++)),
         table_name,
@@ -481,81 +561,67 @@ void QueryAssembler::TranslatePrimaryKey(
 }
 void QueryAssembler::TranslateForeignKey(
     std::shared_ptr<Node> key,
-    std::string &constraint_name,
-    std::string &table_name) {
+    std::string& table_name) {
+  if (key->get_st_type() != StatementType::foreignKey) {
+    LOG(ERROR, "incorrect type for foreignKey node");
+    exit(EXIT_FAILURE);
+  }
+  if (key->get_children_amount() == 0) {
+    LOG(ERROR, "PRIMARY KEY definition is missed");
+    exit(EXIT_FAILURE);
+  }
+  int reference_child_num = 1;
+
   std::vector<std::string> properties;
   properties.push_back(this->TranslateIdentifier(key->get_child(0)));
-
-  int reference_child_num = 1;
   if (key->get_children_amount() > 2) {
+    if (key->get_child(1)->get_st_type() != StatementType::delimiter_comma) {
+      LOG(ERROR, "invalid delimiter between properties in foreign key");
+      exit(EXIT_FAILURE);
+    }
     reference_child_num++;
-
-    std::vector<std::string> other_prop =
-        this->GetListOfProperties(key->get_child(1));
+    std::vector<std::string> other_properties =
+        this->GetListOf(key->get_child(1), StatementType::identifier);
     properties.insert(properties.end(),
-                      other_prop.begin(),
-                      other_prop.end());
+                      other_properties.begin(),
+                      other_properties.end());
   }
 
   // Get reference
   auto reference = key->get_child(reference_child_num);
+  if (reference->get_st_type() != StatementType::reference) {
+    LOG(ERROR, "invalid foreign key: incorrect referene statement type");
+    exit(EXIT_FAILURE);
+  }
+  if (reference->get_children_amount() == 0) {
+    LOG(ERROR, "empty reference");
+    exit(EXIT_FAILURE);
+  }
   auto table_name_node = reference->get_child(0);
   std::string ref_table_name = this->TranslateName(table_name_node);
 
   // Get ref columns if present
   std::vector<std::string> ref_columns;
-
-  size_t table_ch_num = table_name_node->get_children_amount();
-  if (table_ch_num > 1) {
-    auto second = table_name_node->get_child(1);
-    size_t prop_num = 1;
-    if (second->get_st_type() == StatementType::delimiter_dot) {
-      prop_num++;
-    }
-    if (table_ch_num > prop_num) {
-      ref_columns.push_back(this->TranslateIdentifier(table_name_node->get_child(
-          prop_num)));
-      prop_num++;
-      if (table_ch_num > prop_num) {
-        std::vector<std::string> other_props =
-            this->GetListOfProperties(table_name_node->get_child(prop_num));
-        ref_columns.insert(ref_columns.end(),
-                           other_props.begin(),
-                           other_props.end());
-      }
+  if (reference->get_children_amount() > 1) {
+    ref_columns.push_back(this->TranslateIdentifier(reference->get_child(1)));
+    if (reference->get_children_amount() > 2) {
+      std::vector<std::string> other_props =
+          this->GetListOf(reference->get_child(2),
+                          StatementType::identifier);
+      ref_columns.insert(ref_columns.end(),
+                         other_props.begin(),
+                         other_props.end());
     }
   }
 
-  // Create Node Property Existence Constraint
-  // for the properties and ref columns
-  for (auto &i: properties) {
-    this->CreateNodePropertyExistenceConstraint(
-        (constraint_name + "_" + std::to_string(constraint_counter++)),
-        table_name,
-        i
-    );
-  }
-  for (auto &i: ref_columns) {
-    this->CreateNodePropertyExistenceConstraint(
-        (constraint_name + "_" + std::to_string(constraint_counter++)),
-        ref_table_name,
-        i
-    );
-  }
-
-  // Create Unique Node Property Constraint
-  // for the ref columns
-
-  this->CreateUniqueNodePropertyConstraint(
-      (constraint_name + std::to_string(constraint_counter++)),
-      ref_table_name,
-      ref_columns
-  );
+  this->RemoveProperties(table_name, properties);
+  this->RemoveProperties(table_name, ref_columns);
+  this->CreateRelationship(table_name, ref_table_name);
 }
 void QueryAssembler::CreateUniqueNodePropertyConstraint(
-    const std::string &constraint_name,
-    const std::string &LabelName,
-    const std::vector<std::string> &properties) {
+    const std::string& constraint_name,
+    const std::string& LabelName,
+    const std::vector<std::string>& properties) {
   out_ << "CREATE CONSTRAINT [" << constraint_name << "]" << std::endl;
   out_ << "FOR (n:" << LabelName << ")" << std::endl;
   out_ << "REQUIRE (";
@@ -568,59 +634,90 @@ void QueryAssembler::CreateUniqueNodePropertyConstraint(
   out_ << ") IS UNIQUE;\n" << std::endl;
 }
 void QueryAssembler::CreateNodePropertyExistenceConstraint(
-    const std::string &constraint_name,
-    const std::string &LabelName,
-    const std::string &property) {
+    const std::string& constraint_name,
+    const std::string& LabelName,
+    const std::string& property) {
   out_ << "CREATE CONSTRAINT [" << constraint_name << "]" << std::endl;
   out_ << "FOR (n:" << LabelName << ")" << std::endl;
   out_ << "REQUIRE (n." << property << ") IS NOT NULL;\n" << std::endl;
 }
-
-std::vector<std::string> QueryAssembler::GetListOfProperties(
-    std::shared_ptr<Node> node) {
-  std::vector<std::string> properties;
-  properties.push_back(this->TranslateIdentifier(node->get_child(0)));
-
-  if (node->get_children_amount() > 1) {
-    std::vector<std::string> other_prop =
-        this->GetListOfProperties(node->get_child(1));
-    properties.insert(properties.end(),
-                      other_prop.begin(),
-                      other_prop.end());
-  }
-
-  return properties;
+void QueryAssembler::CreateRelationship(
+    const std::string& label_name,
+    const std::string& ref_label_name) {
+  out_ << "MATCH (a:" << label_name << "), (b:" << ref_label_name << ")\n";
+  out_ << "CREATE (a)-[r:fk_"
+       << label_name << "_to_" << ref_label_name << "_" << relationship_counter
+       << "]->(b)\n" << std::endl;
+  relationship_counter++;
 }
-std::vector<std::string> QueryAssembler::GetListOfNames(
-    std::shared_ptr<Node> node) {
-  std::vector<std::string> names;
-  names.push_back(this->TranslateName(node->get_child(0)));
+void QueryAssembler::RemoveProperties(
+    const std::string& label_name,
+    const std::vector<std::string>& properties) {
+  if (properties.empty()) {
+    return;
+  }
+  out_ << "MATCH (n:" << label_name << ")\n";
+  out_ << "SET ";
+  for (size_t i = 0; i < properties.size(); i++) {
+    out_ << "n." << properties[i] << " = null";
+    if (i + 1 != properties.size()) {
+      out_ << ", ";
+    }
+  }
+  out_ << ";\n" << std::endl;
+}
 
-  if (node->get_children_amount() > 1) {
-    std::vector<std::string> other_names =
-        this->GetListOfNames(node->get_child(1));
-    names.insert(names.end(),
-                 other_names.begin(),
-                 other_names.end());
+std::vector<std::string> QueryAssembler::GetListOf(
+    std::shared_ptr<Node> node,
+    StatementType type) {
+  if (node->get_st_type() != StatementType::delimiter_comma) {
+    LOG(ERROR, "invalid ListOf: delimiter is not a comma");
+    exit(EXIT_FAILURE);
+  }
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "invalid ListOf: comma without children");
+    exit(EXIT_FAILURE);
   }
 
-  return names;
+  std::vector<std::string> arguments;
+  switch (type) {
+    case StatementType::name:
+      arguments.push_back(this->TranslateName(node->get_child(0)));
+      break;
+    case StatementType::identifier:
+      arguments.push_back(this->TranslateIdentifier(node->get_child(0)));
+      break;
+    default:
+      LOG(ERROR, "invalid ListOf: unknown argument type");
+      exit(EXIT_FAILURE);
+  }
+
+  if (node->get_children_amount() > 1) {
+    std::vector<std::string> other_arguments =
+        this->GetListOf(node->get_child(1), type);
+    arguments.insert(arguments.end(),
+                     other_arguments.begin(),
+                     other_arguments.end());
+  }
+
+  return arguments;
 }
 
 std::string QueryAssembler::TranslateName(std::shared_ptr<Node> node) {
   if (node->get_children_amount() == 0) {
     LOG(ERROR, "empty name");
-    return "";
+    exit(EXIT_FAILURE);
   }
 
   std::ostringstream name;
 
   name << this->TranslateIdentifier(node->get_child(0));
-
   if (node->get_children_amount() > 1) {
-    auto dot = node->get_child(1);
-    if (dot->get_st_type() == StatementType::delimiter_dot) {
+    if (node->get_child(1)->get_st_type() == StatementType::delimiter_dot) {
       name << this->TranslateIdentifiers(node->get_child(1));
+    } else {
+      LOG(ERROR, "invalid name: incorrect delimiter");
+      exit(EXIT_FAILURE);
     }
   }
 
@@ -630,7 +727,7 @@ std::string QueryAssembler::TranslateIdentifiers(
     std::shared_ptr<Node> node) {
   if (node->get_children_amount() == 0) {
     LOG(ERROR, "invalid list of identifiers");
-    return "";
+    exit(EXIT_FAILURE);
   }
 
   std::ostringstream identifiers;
@@ -642,15 +739,11 @@ std::string QueryAssembler::TranslateIdentifiers(
 
   return identifiers.str();
 }
-std::string QueryAssembler::TranslateIdentifier(
-    std::shared_ptr<Node> node) {
+std::string QueryAssembler::TranslateIdentifier(std::shared_ptr<Node> node) {
   if (node->get_children_amount() == 0) {
     LOG(ERROR, "empty identifier");
-    return "";
+    exit(EXIT_FAILURE);
   }
 
-  auto string_node =
-      std::dynamic_pointer_cast<StringNode>(node->get_child(0));
-
-  return string_node->get_data();
+  return std::dynamic_pointer_cast<StringNode>(node->get_child(0))->get_data();
 }

--- a/src/query_assembler.cpp
+++ b/src/query_assembler.cpp
@@ -1,1 +1,656 @@
 #include "SCC/query_assembler.h"
+
+void QueryAssembler::Translate(std::shared_ptr<Node> AST) {
+  LOG(INFO, "Starting translation...");
+
+  ast_ = std::move(AST);
+
+  if (ast_ == nullptr) {
+    LOG(TRACE, "empty AST, nothing to translate");
+    return;
+  }
+
+  if (ast_->get_st_type() == StatementType::Program) {
+    if (ast_->get_children_amount() > 0) {
+      this->TranslateProgram(ast_);
+    } else {
+      LOG(TRACE, "root of AST does not have children");
+      return;
+    }
+  } else {
+    LOG(ERROR,
+        "invalid AST: root should be with \'Program\' statement type");
+    exit(EXIT_FAILURE);
+  }
+
+  LOG(INFO, "Translation is ended");
+}
+
+void QueryAssembler::TranslateProgram(std::shared_ptr<Node> node) {
+  auto query = node->get_child(0);
+  if (query->get_st_type() == StatementType::query) {
+    this->TranslateQuery(query);
+  } else {
+    LOG(ERROR, "first child of program node is not a query");
+    exit(EXIT_FAILURE);
+  }
+
+  if (node->get_children_amount() > 1) {
+    auto other_queries = node->get_child(1);
+    if (other_queries->get_st_type() == StatementType::delimiter_semicolon) {
+      if (other_queries->get_children_amount() > 0) {
+        this->TranslateProgram(other_queries);
+      }
+    } else {
+      LOG(ERROR, "invalid delimiter between queries");
+      exit(EXIT_FAILURE);
+    }
+  }
+}
+void QueryAssembler::TranslateQuery(std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(TRACE, "empty query");
+    return;
+  }
+
+  auto data_language = node->get_child(0);
+  switch (data_language->get_st_type()) {
+    case StatementType::ddlStatement:this->TranslateDDLStatement(data_language);
+      break;
+    case StatementType::dmlStatement:this->TranslateDMLStatement(data_language);
+      break;
+    default:LOG(ERROR, "unknown query data language");
+      exit(EXIT_FAILURE);
+  }
+}
+
+void QueryAssembler::TranslateDDLStatement(std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(TRACE, "empty DDL query");
+    return;
+  }
+
+  auto statement = node->get_child(0);
+  switch (statement->get_st_type()) {
+    case StatementType::createDatabaseStatement:
+      this->TranslateCreateDatabase(statement);
+      break;
+    case StatementType::createTableStatement:
+      this->TranslateCreateTable(statement);
+      break;
+    case StatementType::alterTableStatement:this->TranslateAlterTable(statement);
+      break;
+    case StatementType::dropDatabaseStatement:
+      this->TranslateDropDatabase(statement);
+      break;
+    case StatementType::dropTableStatement:this->TranslateDropTable(statement);
+      break;
+    default:LOG(ERROR, "unknown DDL statement");
+      exit(EXIT_FAILURE);
+  }
+}
+void QueryAssembler::TranslateDMLStatement(std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(TRACE, "empty DML query");
+  }
+
+  auto statement = node->get_child(0);
+  switch (statement->get_st_type()) {
+    case StatementType::insertStatement:this->TranslateInsert(statement);
+      break;
+    case StatementType::deleteStatement:this->TranslateDelete(statement);
+      break;
+    case StatementType::updateStatement:this->TranslateUpdate(statement);
+      break;
+    default:LOG(ERROR, "unknown DML statement");
+      exit(EXIT_FAILURE);
+  }
+}
+
+void QueryAssembler::TranslateCreateDatabase(std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "database name is missed");
+    exit(EXIT_FAILURE);
+  }
+
+  out_ << "CREATE DATABASE "
+       << this->TranslateName(node->get_child(0))
+       << ";\n" << std::endl;
+}
+void QueryAssembler::TranslateCreateTable(std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "table name is missed");
+    exit(EXIT_FAILURE);
+  }
+
+  std::string table_name = this->TranslateName(node->get_child(0));
+  out_ << "CREATE (:" << table_name;
+
+  if (node->get_children_amount() < 2) {
+    LOG(ERROR, "table definition is missed");
+    exit(EXIT_FAILURE);
+  }
+  auto table_definition = node->get_child(1);
+  if (table_definition->get_children_amount() == 0) {
+    LOG(ERROR, "invalid table: empty table definition");
+    exit(EXIT_FAILURE);
+  }
+
+  // Get properties
+  auto column_definition = table_definition->get_child(0);
+  if (column_definition->get_st_type() != StatementType::columnDefinition) {
+    LOG(ERROR, "table without columns should not be created");
+    exit(EXIT_FAILURE);
+  }
+
+  out_ << " {";
+
+  StdProperty first_property =
+      this->TranslateColumnDefinition(column_definition);
+  out_ << std::get<0>(first_property) << ": "
+       << std::get<1>(first_property);
+
+  if (table_definition->get_children_amount() > 1) {
+    auto comma = table_definition->get_child(1);
+    if (comma->get_st_type() != StatementType::delimiter_comma) {
+      LOG(ERROR, "delimiter in the table definition is not a comma");
+      exit(EXIT_FAILURE);
+    }
+
+    if (comma->get_child(0)->get_st_type()
+        == StatementType::columnDefinition) {
+      std::vector<StdProperty> other_props =
+          this->TranslateListOfColumnDefinitions(comma);
+      for (auto &i: other_props) {
+        out_ << ", " << std::get<0>(i) << ": " << std::get<1>(i);
+      }
+    }
+  }
+
+  out_ << "});\n" << std::endl;
+
+  // Get constraints
+  if (table_definition->get_children_amount() > 1) {
+    auto constraints = this->FindConstraint(table_definition->get_child(1));
+    if (constraints != nullptr) {
+      this->TranslateTableConstraint(constraints, table_name);
+    }
+  }
+}
+void QueryAssembler::TranslateAlterTable(std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "table name is missed");
+    exit(EXIT_FAILURE);
+  }
+
+  std::string table_name = this->TranslateName(node->get_child(0));
+
+  if (node->get_children_amount() < 2) {
+    LOG(ERROR, "alter table action is missed");
+    exit(EXIT_FAILURE);
+  }
+
+  auto action_node = node->get_child(1);
+  if (action_node->get_st_type() == StatementType::alterActionADD) {
+    if (action_node->get_children_amount() < 1) {
+      LOG(ERROR, "alter table ADD without content");
+      exit(EXIT_FAILURE);
+    }
+    auto table_definition = action_node->get_child(0);
+
+    if (table_definition->get_children_amount() < 1) {
+      LOG(ERROR, "alter table ADD action without arguments");
+      exit(EXIT_FAILURE);
+    }
+    auto first_argument = table_definition->get_child(0);
+
+    bool is_constraint_first = true;
+
+    // Get column definitions
+    if (first_argument->get_st_type() == StatementType::columnDefinition) {
+      is_constraint_first = false;
+
+      out_ << "MATCH (n:" << table_name << ")\n";
+      out_ << "SET ";
+
+      StdProperty first_prop =
+          this->TranslateColumnDefinition(first_argument);
+      out_ << "n." << std::get<0>(first_prop)
+           << " = " << std::get<1>(first_prop);
+
+      if (table_definition->get_children_amount() > 1) {
+        auto comma = table_definition->get_child(1);
+        if (comma->get_st_type() != StatementType::delimiter_comma) {
+          LOG(ERROR, "delimiter between column definitions is not a comma");
+          exit(EXIT_FAILURE);
+        }
+
+        if (comma->get_child(0)->get_st_type()
+            == StatementType::columnDefinition) {
+          std::vector<StdProperty> other_props =
+              this->TranslateListOfColumnDefinitions(comma);
+
+          for (auto& i : other_props) {
+            out_ << ", n." << std::get<0>(i)
+                 << " = " << std::get<1>(i);
+          }
+        }
+      }
+
+      out_ << ";\n" << std::endl;
+    }
+
+    // Get table constraints
+    if (is_constraint_first) {
+      this->TranslateTableConstraint(table_definition, table_name);
+    } else {
+      auto constraints =
+          this->FindConstraint(table_definition->get_child(1));
+      if (constraints != nullptr) {
+        this->TranslateTableConstraint(constraints, table_name);
+      }
+    }
+  } else if (action_node->get_st_type() == StatementType::alterActionDROP) {
+    if (action_node->get_children_amount() < 1) {
+      LOG(ERROR, "alter table DROP without content");
+      exit(EXIT_FAILURE);
+    }
+    auto drop_list_def = action_node->get_child(0);
+
+    if (drop_list_def->get_children_amount() < 1) {
+      LOG(ERROR, "alter table DROP without arguments");
+    }
+    auto object = drop_list_def->get_child(0);
+
+    this->TranslateDropObject(object, table_name);
+
+    if (drop_list_def->get_children_amount() > 1) {
+      auto other_objects = drop_list_def->get_child(1);
+      this->TranslateListOfDropObjects(other_objects, table_name);
+    }
+  }
+}
+void QueryAssembler::TranslateDropDatabase(std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "database name is missed");
+    return;
+  }
+
+  std::vector<std::string> db_names;
+  db_names.push_back(this->TranslateName(node->get_child(0)));
+
+  if (node->get_children_amount() > 1) {
+    std::vector<std::string> other_db_names =
+        this->GetListOfNames(node->get_child(1));
+    db_names.insert(db_names.end(),
+                    other_db_names.begin(),
+                    other_db_names.end());
+  }
+
+  for (auto &i: db_names) {
+    out_ << "DROP DATABASE " << i << ";\n" << std::endl;
+  }
+}
+void QueryAssembler::TranslateDropTable(std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "table name is missed");
+    return;
+  }
+
+  std::vector<std::string> table_names;
+  table_names.push_back(this->TranslateName(node->get_child(0)));
+
+  if (node->get_children_amount() > 1) {
+    std::vector<std::string> other_table_names =
+        this->GetListOfNames(node->get_child(1));
+    table_names.insert(table_names.end(),
+                       other_table_names.begin(),
+                       other_table_names.end());
+  }
+
+  for (auto &i: table_names) {
+    out_ << "MATCH (x:" << i << ") DELETE x;\n" << std::endl;
+  }
+}
+
+std::vector<StdProperty> QueryAssembler::TranslateListOfColumnDefinitions(
+    std::shared_ptr<Node> node) {
+  auto first = node->get_child(0);
+  if (first->get_st_type() != StatementType::columnDefinition) {
+    LOG(TRACE, "list of column definitions is ended");
+    return {};
+  }
+
+  std::vector<StdProperty> list_of_cols;
+  list_of_cols.push_back(this->TranslateColumnDefinition(first));
+  if (node->get_children_amount() > 1) {
+    auto comma = node->get_child(1);
+    if ((comma->get_child(0))->get_st_type()
+        == StatementType::columnDefinition) {
+      std::vector<StdProperty> other_cols =
+          this->TranslateListOfColumnDefinitions(node->get_child(1));
+
+      list_of_cols.insert(list_of_cols.end(),
+                          other_cols.begin(),
+                          other_cols.end());
+    }
+  }
+
+  return list_of_cols;
+}
+StdProperty QueryAssembler::TranslateColumnDefinition(
+    std::shared_ptr<Node> node) {
+  std::string column_name = this->TranslateIdentifier(node->get_child(0));
+
+  auto datatype_node = node->get_child(1);
+  StatementType datatype = datatype_node->get_st_type();
+
+  std::string datatype_str;
+  switch (datatype) {
+    case StatementType::SQL_int:datatype_str = "0";
+      break;
+    case StatementType::SQL_float:datatype_str = "0.0";
+      break;
+    case StatementType::SQL_char:
+    case StatementType::SQL_varchar:datatype_str = "\"\"";
+      break;
+    default:LOG(ERROR, "unknown SQL datatype");
+      datatype_str = "null";
+  }
+
+  return std::tie(column_name, datatype_str);
+}
+
+void QueryAssembler::TranslateTableConstraint(std::shared_ptr<Node> node,
+                                              std::string table_name) {
+  int child_with_key = 0;
+  std::string constraint_name;
+
+  auto constraint_serv_node = node->get_child(0);
+  if (constraint_serv_node->get_children_amount() > 1) {
+    child_with_key++;
+    auto constraint_kw = constraint_serv_node->get_child(0);
+    constraint_name +=
+        this->TranslateIdentifier(constraint_kw->get_child(0));
+  } else {
+    constraint_name = "constraint";
+  }
+
+  // Translate constraint
+  auto key = constraint_serv_node->get_child(child_with_key);
+  if (key->get_st_type() == StatementType::primaryKey) {
+    this->TranslatePrimaryKey(key, constraint_name, table_name);
+  } else if (key->get_st_type() == StatementType::foreignKey) {
+    this->TranslateForeignKey(key, constraint_name, table_name);
+  }
+
+  if (node->get_children_amount() > 1) {
+    this->TranslateTableConstraint(
+        node->get_child(1),
+        table_name);
+  }
+}
+std::shared_ptr<Node> QueryAssembler::FindConstraint(
+    std::shared_ptr<Node> node) {
+  std::shared_ptr<Node> constraints = nullptr;
+
+  auto left = node->get_child(0);
+  if (left->get_st_type() == StatementType::tableConstraint) {
+    constraints = node;
+  } else {
+    if (node->get_children_amount() > 1) {
+      constraints = this->FindConstraint(node->get_child(1));
+    }
+  }
+
+  return constraints;
+}
+
+void QueryAssembler::TranslateDropObject(
+    std::shared_ptr<Node> node,
+    std::string table_name) {
+  StatementType drop_type = node->get_st_type();
+  if (drop_type == StatementType::dropColumn) {
+    std::vector<std::string> properties = this->GetListOfProperties(node);
+
+    out_ << "MATCH (n:" << table_name << ")\n";
+    out_ << "SET ";
+    for (size_t i = 0; i < properties.size(); i++) {
+      out_ << "n." << properties[i] << " = null";
+      if (i + 1 != properties.size()) {
+        out_ << ", ";
+      }
+    }
+    out_ << ";\n" << std::endl;
+  } else if (drop_type == StatementType::dropConstraint) {
+    std::vector<std::string> constraints = this->GetListOfProperties(node);
+    for (auto &i: constraints) {
+      out_ << "DROP CONSTRAINT " << i;
+      out_ << ";\n" << std::endl;
+    }
+  } else {
+    LOG(ERROR, "unknown type for the drop object");
+    return;
+  }
+}
+void QueryAssembler::TranslateListOfDropObjects(
+    std::shared_ptr<Node> node,
+    std::string table_name) {
+  auto object = node->get_child(0);
+  this->TranslateDropObject(object, table_name);
+
+  if (node->get_children_amount() > 1) {
+    auto other_objects = node->get_child(1);
+    this->TranslateListOfDropObjects(other_objects, table_name);
+  }
+}
+
+void QueryAssembler::TranslateInsert(std::shared_ptr<Node> node) {}
+void QueryAssembler::TranslateDelete(std::shared_ptr<Node> node) {}
+void QueryAssembler::TranslateUpdate(std::shared_ptr<Node> node) {}
+
+// Basic statements
+
+void QueryAssembler::TranslatePrimaryKey(
+    std::shared_ptr<Node> key,
+    std::string &constraint_name,
+    std::string &table_name) {
+  std::vector<std::string> properties;
+  properties.push_back(this->TranslateIdentifier(key->get_child(0)));
+
+  if (key->get_children_amount() > 1) {
+    std::vector<std::string> other_prop =
+        this->GetListOfProperties(key->get_child(1));
+    properties.insert(properties.end(),
+                      other_prop.begin(),
+                      other_prop.end());
+  }
+
+  this->CreateUniqueNodePropertyConstraint(
+      (constraint_name + "_" + std::to_string(constraint_counter++)),
+      table_name,
+      properties
+  );
+  for (auto &i: properties) {
+    this->CreateNodePropertyExistenceConstraint(
+        (constraint_name + "_" + std::to_string(constraint_counter++)),
+        table_name,
+        i
+    );
+  }
+}
+void QueryAssembler::TranslateForeignKey(
+    std::shared_ptr<Node> key,
+    std::string &constraint_name,
+    std::string &table_name) {
+  std::vector<std::string> properties;
+  properties.push_back(this->TranslateIdentifier(key->get_child(0)));
+
+  int reference_child_num = 1;
+  if (key->get_children_amount() > 2) {
+    reference_child_num++;
+
+    std::vector<std::string> other_prop =
+        this->GetListOfProperties(key->get_child(1));
+    properties.insert(properties.end(),
+                      other_prop.begin(),
+                      other_prop.end());
+  }
+
+  // Get reference
+  auto reference = key->get_child(reference_child_num);
+  auto table_name_node = reference->get_child(0);
+  std::string ref_table_name = this->TranslateName(table_name_node);
+
+  // Get ref columns if present
+  std::vector<std::string> ref_columns;
+
+  size_t table_ch_num = table_name_node->get_children_amount();
+  if (table_ch_num > 1) {
+    auto second = table_name_node->get_child(1);
+    size_t prop_num = 1;
+    if (second->get_st_type() == StatementType::delimiter_dot) {
+      prop_num++;
+    }
+    if (table_ch_num > prop_num) {
+      ref_columns.push_back(this->TranslateIdentifier(table_name_node->get_child(
+          prop_num)));
+      prop_num++;
+      if (table_ch_num > prop_num) {
+        std::vector<std::string> other_props =
+            this->GetListOfProperties(table_name_node->get_child(prop_num));
+        ref_columns.insert(ref_columns.end(),
+                           other_props.begin(),
+                           other_props.end());
+      }
+    }
+  }
+
+  // Create Node Property Existence Constraint
+  // for the properties and ref columns
+  for (auto &i: properties) {
+    this->CreateNodePropertyExistenceConstraint(
+        (constraint_name + "_" + std::to_string(constraint_counter++)),
+        table_name,
+        i
+    );
+  }
+  for (auto &i: ref_columns) {
+    this->CreateNodePropertyExistenceConstraint(
+        (constraint_name + "_" + std::to_string(constraint_counter++)),
+        ref_table_name,
+        i
+    );
+  }
+
+  // Create Unique Node Property Constraint
+  // for the ref columns
+
+  this->CreateUniqueNodePropertyConstraint(
+      (constraint_name + std::to_string(constraint_counter++)),
+      ref_table_name,
+      ref_columns
+  );
+}
+void QueryAssembler::CreateUniqueNodePropertyConstraint(
+    const std::string &constraint_name,
+    const std::string &LabelName,
+    const std::vector<std::string> &properties) {
+  out_ << "CREATE CONSTRAINT [" << constraint_name << "]" << std::endl;
+  out_ << "FOR (n:" << LabelName << ")" << std::endl;
+  out_ << "REQUIRE (";
+  for (size_t i = 0; i < properties.size(); i++) {
+    out_ << "n." << properties[i];
+    if (i + 1 != properties.size()) {
+      out_ << ", ";
+    }
+  }
+  out_ << ") IS UNIQUE;\n" << std::endl;
+}
+void QueryAssembler::CreateNodePropertyExistenceConstraint(
+    const std::string &constraint_name,
+    const std::string &LabelName,
+    const std::string &property) {
+  out_ << "CREATE CONSTRAINT [" << constraint_name << "]" << std::endl;
+  out_ << "FOR (n:" << LabelName << ")" << std::endl;
+  out_ << "REQUIRE (n." << property << ") IS NOT NULL;\n" << std::endl;
+}
+
+std::vector<std::string> QueryAssembler::GetListOfProperties(
+    std::shared_ptr<Node> node) {
+  std::vector<std::string> properties;
+  properties.push_back(this->TranslateIdentifier(node->get_child(0)));
+
+  if (node->get_children_amount() > 1) {
+    std::vector<std::string> other_prop =
+        this->GetListOfProperties(node->get_child(1));
+    properties.insert(properties.end(),
+                      other_prop.begin(),
+                      other_prop.end());
+  }
+
+  return properties;
+}
+std::vector<std::string> QueryAssembler::GetListOfNames(
+    std::shared_ptr<Node> node) {
+  std::vector<std::string> names;
+  names.push_back(this->TranslateName(node->get_child(0)));
+
+  if (node->get_children_amount() > 1) {
+    std::vector<std::string> other_names =
+        this->GetListOfNames(node->get_child(1));
+    names.insert(names.end(),
+                 other_names.begin(),
+                 other_names.end());
+  }
+
+  return names;
+}
+
+std::string QueryAssembler::TranslateName(std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "empty name");
+    return "";
+  }
+
+  std::ostringstream name;
+
+  name << this->TranslateIdentifier(node->get_child(0));
+
+  if (node->get_children_amount() > 1) {
+    auto dot = node->get_child(1);
+    if (dot->get_st_type() == StatementType::delimiter_dot) {
+      name << this->TranslateIdentifiers(node->get_child(1));
+    }
+  }
+
+  return name.str();
+}
+std::string QueryAssembler::TranslateIdentifiers(
+    std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "invalid list of identifiers");
+    return "";
+  }
+
+  std::ostringstream identifiers;
+  identifiers << "." << this->TranslateIdentifier(node->get_child(0));
+
+  if (node->get_children_amount() > 1) {
+    identifiers << this->TranslateIdentifiers(node->get_child(1));
+  }
+
+  return identifiers.str();
+}
+std::string QueryAssembler::TranslateIdentifier(
+    std::shared_ptr<Node> node) {
+  if (node->get_children_amount() == 0) {
+    LOG(ERROR, "empty identifier");
+    return "";
+  }
+
+  auto string_node =
+      std::dynamic_pointer_cast<StringNode>(node->get_child(0));
+
+  return string_node->get_data();
+}

--- a/src/syntax_analyzer.cpp
+++ b/src/syntax_analyzer.cpp
@@ -1165,7 +1165,7 @@ std::shared_ptr<Node> SyntaxAnalyzer::GetReference() {
       return reference;
     } else {
       ref_column_name = this->GetIdentifier();
-      SyntaxAnalyzer::MakeKinship(ref_table_name, ref_column_name);
+      SyntaxAnalyzer::MakeKinship(reference, ref_column_name);
 
       if (tokens_array_.empty()) {
         LOG(ERROR, "invalid reference: closing round bracket is missed");
@@ -1174,7 +1174,7 @@ std::shared_ptr<Node> SyntaxAnalyzer::GetReference() {
         if (SyntaxAnalyzer::IsComma(this->peek_first_token())) {
           next_ref_column_names =
               this->GetListOf(StatementType::identifier);
-          SyntaxAnalyzer::MakeKinship(ref_table_name, next_ref_column_names);
+          SyntaxAnalyzer::MakeKinship(reference, next_ref_column_names);
         }
       }
     }


### PR DESCRIPTION
Added class `QueryAssembler` and implemented methods, which translate AST from `SyntaxAnalyzer` to code on CQL.
For now, Query Assembler can translate the same DDL queries, which Syntax Analyzer can process.