### PR TITLE
Patch: repair tree dump generation

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -126,10 +126,12 @@ void Config::Start(int argc, char* argv[]) {
   this->ValidateCypherPath();
   this->ValidateIsOutputStreamOpen();
 
-  tree_dump_.open(tree_dump_path_, std::ios::out);
-  this->ValidateTreeDumpPath();
-  this->ValidateIsTreeDumpStreamOpen();
-  
+  if (is_need_dump_) {
+    tree_dump_.open(tree_dump_path_, std::ios::out);
+    this->ValidateTreeDumpPath();
+    this->ValidateIsTreeDumpStreamOpen();
+  }
+
   LOG(TRACE, "all i/o files are opened");
 
   SCC_log.set_is_system_configured(true);

--- a/test/SQL_AST_test/SQL_AST_test.cpp
+++ b/test/SQL_AST_test/SQL_AST_test.cpp
@@ -41,6 +41,9 @@ protected:
                       std::istreambuf_iterator<char>(file2.rdbuf()));
   }
 
+  void SetUp() override {
+    config.set_is_need_dump(true);
+  }
   void TearDown() override {
     config.CloseInputFile();
     config.CloseOutputFile();
@@ -308,6 +311,9 @@ protected:
                       std::istreambuf_iterator<char>(file2.rdbuf()));
   }
 
+  void SetUp() override {
+    config.set_is_need_dump(true);
+  }
   void TearDown() override {
     config.CloseInputFile();
     config.CloseOutputFile();
@@ -455,6 +461,9 @@ protected:
                       std::istreambuf_iterator<char>(file2.rdbuf()));
   }
 
+  void SetUp() override {
+    config.set_is_need_dump(true);
+  }
   void TearDown() override {
     config.CloseInputFile();
     config.CloseOutputFile();


### PR DESCRIPTION
In package now tree dump will be generated only with the flag `--dump`. Locally, will be generated in the default folder.