### PR TITLE
[#40] Remove separators and Recursion during parsing and translation

### DIFF
--- a/include/SCC/ast/stmt_types.h
+++ b/include/SCC/ast/stmt_types.h
@@ -24,8 +24,9 @@ constexpr std::string_view kST_TABLE_DEF = "table definition";
 constexpr std::string_view kST_COLUMN_DEF = "column definition";
 constexpr std::string_view kST_TABLE_CONSTRAINT = "table constraint";
 constexpr std::string_view kST_ALTER_ACTION_ADD = "alter action add";
+constexpr std::string_view kST_ALTER_ADD_LIST = "alter add list";
 constexpr std::string_view kST_ALTER_ACTION_DROP = "alter action drop";
-constexpr std::string_view kST_DROP_LIST = "drop list";
+constexpr std::string_view kST_ALTER_DROP_LIST = "alter drop list";
 constexpr std::string_view kST_DROP_CONSTRAINT = "drop constraint";
 constexpr std::string_view kST_DROP_COLUMN = "drop column";
 
@@ -85,8 +86,9 @@ public:
     kColumnDef,
     kTableConstraint,
     kAlterActionAdd,
+    kAlterAddList,
     kAlterActionDrop,
-    kDropList,
+    kAlterDropList,
     kDropConstraint,
     kDropColumn,
 

--- a/include/SCC/parser/parser.h
+++ b/include/SCC/parser/parser.h
@@ -58,14 +58,15 @@ private:
   std::shared_ptr<ast::INode> ParseDropTableStatement();
 
   std::shared_ptr<ast::INode> ParseTableDefinition();
-  std::shared_ptr<ast::INode> ParseTableDefinitionElements();
   std::shared_ptr<ast::INode> ParseTableDefinitionElement();
   ast::StmtType ParseTableDefinitionElementType();
   std::shared_ptr<ast::INode> ParseColumnDefinition();
   std::shared_ptr<ast::INode> ParseTableConstraint(ast::StmtType stmt_type = ast::StmtType::kNone);
 
-  std::shared_ptr<ast::INode> ParseDropListDefinition();
-  std::shared_ptr<ast::INode> ParseDropElement();
+  std::shared_ptr<ast::INode> ParseAlterAddListDefinition();
+  std::shared_ptr<ast::INode> ParseAlterAddElement();
+  std::shared_ptr<ast::INode> ParseAlterDropListDefinition();
+  std::shared_ptr<ast::INode> ParseAlterDropElement();
 
   std::shared_ptr<ast::INode> ParseInsertStatement();
   std::shared_ptr<ast::INode> ParseDeleteStatement();

--- a/include/SCC/parser/parser.h
+++ b/include/SCC/parser/parser.h
@@ -65,7 +65,6 @@ private:
   std::shared_ptr<ast::INode> ParseTableConstraint(ast::StmtType stmt_type = ast::StmtType::kNone);
 
   std::shared_ptr<ast::INode> ParseDropListDefinition();
-  std::shared_ptr<ast::INode> ParseDropElements();
   std::shared_ptr<ast::INode> ParseDropElement();
 
   std::shared_ptr<ast::INode> ParseInsertStatement();

--- a/include/SCC/parser/parser.h
+++ b/include/SCC/parser/parser.h
@@ -45,7 +45,6 @@ private:
 
   std::shared_ptr<ast::INode> ParseQuery();
   std::shared_ptr<ast::INode> ParseBaseStatement();
-  std::shared_ptr<ast::INode> ParseNextQueries();
 
   ast::StmtType ParseDDLStatementType();
   ast::StmtType ParseDMLStatementType();

--- a/include/SCC/parser/parser.h
+++ b/include/SCC/parser/parser.h
@@ -40,7 +40,7 @@ public:
 private:
   std::deque<std::shared_ptr<ast::INode>> tokens_;
 
-  const std::shared_ptr<ast::INode>& PeekToken() const;
+  const std::shared_ptr<ast::INode>& PeekToken(unsigned idx = 0) const;
   std::shared_ptr<ast::INode> NextToken();
 
   std::shared_ptr<ast::INode> ParseQuery();
@@ -67,6 +67,7 @@ private:
   std::shared_ptr<ast::INode> ParseAlterAddElement();
   std::shared_ptr<ast::INode> ParseAlterDropListDefinition();
   std::shared_ptr<ast::INode> ParseAlterDropElement();
+  void ParseAlterDropColumns(std::shared_ptr<ast::INode>& parent);
 
   std::shared_ptr<ast::INode> ParseInsertStatement();
   std::shared_ptr<ast::INode> ParseDeleteStatement();
@@ -113,7 +114,9 @@ private:
   std::shared_ptr<ast::INode> ParseName();
   std::shared_ptr<ast::INode> ParseIdentifier();
 
+  bool HasTokens(unsigned min_count = 1) const;
   void ValidateHasTokens(const std::string& details = "") const;
+  void ValidateHasTokens(unsigned min_count = 1) const;
   void ValidateHasNotTokens() const;
   void ValidateIsWord(const std::shared_ptr<ast::INode>& node) const;
   void ValidateIsOpeningRoundBracket(const std::shared_ptr<ast::INode>& node) const;

--- a/include/SCC/parser/parser.h
+++ b/include/SCC/parser/parser.h
@@ -111,7 +111,6 @@ private:
   std::shared_ptr<ast::INode> ParseDataType();
   std::shared_ptr<ast::INode> ParseString();
   std::shared_ptr<ast::INode> ParseName();
-  std::shared_ptr<ast::INode> ParseIdentifiers();
   std::shared_ptr<ast::INode> ParseIdentifier();
 
   void ValidateHasTokens(const std::string& details = "") const;

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -51,6 +51,7 @@ struct Node {
   Node& AddProperty(const NodeProperty& property);
   Node& AddProperty(const std::string& name, const std::string& value, PropertyType type);
   bool HasProperty(const std::string& name) const;
+  unsigned PropertyCount() const;
   Node& AddLabel(const Label& label);
   Node& AddLabel(const std::string& label);
   Node& SetVariable(const std::string& variable);

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -68,10 +68,8 @@ private:
   std::vector<cypher::NodeProperty> TranslateColumnDefinitions(
       const std::shared_ptr<ast::INode>& column_definition);
   cypher::NodeProperty TranslateColumnDefinition(const std::shared_ptr<ast::INode>& node);
-
-  void TranslateListOfTableConstraints(const std::shared_ptr<ast::INode>& node,
-                                       std::string& table_name);
-  std::shared_ptr<ast::INode> FindConstraint(const std::shared_ptr<ast::INode>& node);
+  void TranslateTableConstraint(const std::shared_ptr<ast::INode>& constraint_definition,
+                                const std::string& table_name);
 
   void TranslateDropElement(const std::shared_ptr<ast::INode>& node, std::string& table_name);
   void TranslateDropElements(const std::shared_ptr<ast::INode>& node, std::string& table_name);

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -72,7 +72,6 @@ private:
                                 const std::string& table_name);
 
   void TranslateDropElement(const std::shared_ptr<ast::INode>& node, std::string& table_name);
-  void TranslateDropElements(const std::shared_ptr<ast::INode>& node, std::string& table_name);
 
   // DML statements
 
@@ -87,8 +86,6 @@ private:
   void TranslateForeignKey(const std::shared_ptr<ast::INode>& foreign_key,
                            const std::string& table_name);
 
-  std::vector<std::string> GetList(const std::shared_ptr<ast::INode>& node,
-                                   ast::StmtType type) const;
   std::string GetName(const std::shared_ptr<ast::INode>& name_node) const;
   std::string GetIdentifier(const std::shared_ptr<ast::INode>& node) const;
 

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -89,8 +89,7 @@ private:
 
   std::vector<std::string> GetList(const std::shared_ptr<ast::INode>& node,
                                    ast::StmtType type) const;
-  std::string GetName(const std::shared_ptr<ast::INode>& node) const;
-  std::string GetIdentifiersJoinedByDot(const std::shared_ptr<ast::INode>& node) const;
+  std::string GetName(const std::shared_ptr<ast::INode>& name_node) const;
   std::string GetIdentifier(const std::shared_ptr<ast::INode>& node) const;
 
   void CreateConstraint(const std::string& constraint_name,

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -47,7 +47,6 @@ private:
   void WriteCypherQuery(const std::string& query);
   void FinishCypherQueriesGroup();
 
-  void TranslateProgram(const std::shared_ptr<ast::INode>& program);
   void TranslateQuery(const std::shared_ptr<ast::INode>& query);
 
   void TranslateDDLStatement(const std::shared_ptr<ast::INode>& ddl_statement);

--- a/src/ast/stmt_types.cpp
+++ b/src/ast/stmt_types.cpp
@@ -41,10 +41,12 @@ StmtType::StmtType(const std::string_view& str_type) {
     this->value_ = kTableConstraint;
   else if (type == kST_ALTER_ACTION_ADD)
     this->value_ = kAlterActionAdd;
+  else if (type == kST_ALTER_ADD_LIST)
+    this->value_ = kAlterAddList;
   else if (type == kST_ALTER_ACTION_DROP)
     this->value_ = kAlterActionDrop;
-  else if (type == kST_DROP_LIST)
-    this->value_ = kDropList;
+  else if (type == kST_ALTER_DROP_LIST)
+    this->value_ = kAlterDropList;
   else if (type == kST_DROP_CONSTRAINT)
     this->value_ = kDropConstraint;
   else if (type == kST_DROP_COLUMN)
@@ -153,10 +155,12 @@ std::string StmtType::ToString() const {
       return std::string(kST_TABLE_CONSTRAINT);
     case kAlterActionAdd:
       return std::string(kST_ALTER_ACTION_ADD);
+    case kAlterAddList:
+      return std::string(kST_ALTER_ADD_LIST);
     case kAlterActionDrop:
       return std::string(kST_ALTER_ACTION_DROP);
-    case kDropList:
-      return std::string(kST_DROP_LIST);
+    case kAlterDropList:
+      return std::string(kST_ALTER_DROP_LIST);
     case kDropConstraint:
       return std::string(kST_DROP_CONSTRAINT);
     case kDropColumn:

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -19,18 +19,20 @@ StmtType Parser::DetermineConstraintType(const std::string& keyword) const {
   return StmtType::kNone;
 }
 StmtType Parser::DetermineAlterTableActionType(const std::string& keyword) const {
-  if (kST_ADD_KW.find(scc::common::LowerCase(keyword)) == 0) {
+  std::string keyword_lower = scc::common::LowerCase(keyword);
+  if (kST_ADD_KW.find(keyword_lower) == 0) {
     return StmtType::kAddKW;
-  } else if (kST_DROP_KW.find(scc::common::LowerCase(keyword)) == 0) {
+  } else if (kST_DROP_KW.find(keyword_lower) == 0) {
     return StmtType::kDropKW;
   }
   return StmtType::kNone;
 }
 StmtType Parser::DetermineDropElementType(const std::string& keyword) const {
-  if (kST_CONSTRAINT_KW.find(keyword) == 0) {
-    return StmtType::kConstraintKW;
-  } else if (kST_COLUMN_KW.find(keyword) == 0) {
-    return StmtType::kColumnKW;
+  std::string keyword_lower = scc::common::LowerCase(keyword);
+  if (kST_CONSTRAINT_KW.find(keyword_lower) == 0) {
+    return StmtType::kDropConstraint;
+  } else if (kST_COLUMN_KW.find(keyword_lower) == 0) {
+    return StmtType::kDropColumn;
   }
   return StmtType::kNone;
 }

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -135,21 +135,25 @@ NodePtr<INode> Parser::ParsePrimaryKey() {
   ValidateHasTokens("Missing \'PRIMARY KEY\' definition at line "
                         + std::to_string(next_token->line));
   int line = PeekToken()->line;
-  ValidateIsOpeningRoundBracket(PeekToken());
-  NextToken();
+  ValidateIsOpeningRoundBracket(NextToken());
 
   ValidateHasTokens("Missed column name at line " + std::to_string(line));
-  NodePtr<INode> column_name = ParseColumnName();
-  ASTUtils::Link(primary_key, column_name);
+  while (!tokens_.empty()) {
+    NodePtr<INode> column_name = ParseColumnName();
+    ASTUtils::Link(primary_key, column_name);
 
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
-    NodePtr<INode> separator = ParseListOf(StmtType::kName);
-    ASTUtils::Link(primary_key, separator);
+    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+      next_token = NextToken();
+      ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                            + ": missing column name after comma");
+      ValidateIsWord(PeekToken());
+    } else {
+      break;
+    }
   }
 
   ValidateHasTokens("Missed closing round bracket at line " + std::to_string(line));
-  ValidateIsClosingRoundBracket(PeekToken());
-  NextToken();
+  ValidateIsClosingRoundBracket(NextToken());
 
   return primary_key;
 }
@@ -176,63 +180,76 @@ NodePtr<INode> Parser::ParseForeignKey() {
                             + ": expected \'KEY\' keyword");
   }
 
-  ValidateHasTokens("Missing \'FOREIGN KEY\' definition at line "
-                        + std::to_string(next_token->line));
+  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                        + ": missing \'FOREIGN KEY\' definition");
   next_token = NextToken();
   ValidateIsOpeningRoundBracket(next_token);
 
-  ValidateHasTokens("Missing referencing column name in \'FOREIGN KEY\' definition at line "
-                        + std::to_string(next_token->line));
-  NodePtr<INode> referencing_column_name = ParseColumnName();
-  ASTUtils::Link(foreign_key, referencing_column_name);
+  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                        + ": missing referencing column name");
+  while (!tokens_.empty()) {
+    NodePtr<INode> referencing_column_name = ParseColumnName();
+    ASTUtils::Link(foreign_key, referencing_column_name);
 
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
-    NodePtr<INode> next_referencing_column_names = ParseListOf(StmtType::kName);
-    ASTUtils::Link(foreign_key, next_referencing_column_names);
+    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+      next_token = NextToken();
+      ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                            + ": missing referencing column name after comma");
+      ValidateIsWord(PeekToken());
+    } else {
+      break;
+    }
   }
 
-  ValidateHasTokens("Missing closing parenthesis in \'FOREIGN KEY\' definition at line "
-                        + std::to_string(referencing_column_name->line));
+  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                        + ": missing closing parenthesis");
   next_token = NextToken();
   ValidateIsClosingRoundBracket(next_token);
 
-  ValidateHasTokens("Missing \'REFERENCES\' keyword in \'FOREIGN KEY\' definition at line "
-                        + std::to_string(next_token->line));
+  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                        + ": missing \'REFERENCES\' keyword");
   NodePtr<INode> reference = ParseReference();
   ASTUtils::Link(foreign_key, reference);
 
   return foreign_key;
 }
 NodePtr<INode> Parser::ParseReference() {
+  std::string incorrect_msg_prefix = "Incorrect \'REFERENCES\' definition at line ";
+
   auto next_token = NextToken();
   ValidateIsWord(next_token);
   std::string references_keyword = ASTUtils::CastToNodeType<StringNode>(next_token)->data;
   if (!DetermineIsReferences(references_keyword)) {
-    throw parsing_error("Incorrect \'REFERENCES\' definition at line "
-                            + std::to_string(next_token->line));
+    throw parsing_error(incorrect_msg_prefix + std::to_string(next_token->line));
   }
   NodePtr<INode> reference = ASTUtils::CreateServiceNode(StmtType::kReferencesKW, next_token);
 
-  ValidateHasTokens("Missing references table name at line " + std::to_string(next_token->line));
+  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                        + ": missing references table name");
   NodePtr<INode> referenced_table_name = ParseTableName();
   ASTUtils::Link(reference, referenced_table_name);
 
   if (!tokens_.empty() && NodeDataClassifier::IsOpeningRoundBracket(PeekToken())) {
     next_token = NextToken();
 
-    ValidateHasTokens("Missing referenced column name at line " + std::to_string(next_token->line));
-    NodePtr<INode> referenced_column_name = ParseColumnName();
-    ASTUtils::Link(reference, referenced_column_name);
+    ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                          + ": missing referenced column name");
+    while (!tokens_.empty()) {
+      NodePtr<INode> referenced_column_name = ParseColumnName();
+      ASTUtils::Link(reference, referenced_column_name);
 
-    ValidateHasTokens("Missing closing parenthesis or comma at line "
-                          + std::to_string(referenced_column_name->line));
-    auto peeked_token = PeekToken();
-    if (NodeDataClassifier::IsComma(peeked_token)) {
-      NodePtr<INode> next_referenced_column_names = ParseListOf(StmtType::kName);
-      ASTUtils::Link(reference, next_referenced_column_names);
+      if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+        next_token = NextToken();
+        ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                              + ": missing referenced column name after comma");
+        ValidateIsWord(PeekToken());
+      } else {
+        break;
+      }
     }
 
-    ValidateHasTokens("Missing closing parenthesis at line " + std::to_string(peeked_token->line));
+    ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
+                          + ": missing closing parenthesis");
     ValidateIsClosingRoundBracket(NextToken());
   }
 

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -305,31 +305,22 @@ NodePtr<INode> Parser::ParseString() {
 }
 NodePtr<INode> Parser::ParseName() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kName, PeekToken());
-  NodePtr<INode> identifier = ParseIdentifier();
-  ASTUtils::Link(service_node, identifier);
 
-  if (!tokens_.empty() && NodeDataClassifier::IsDot(PeekToken())) {
-    NodePtr<INode> next_identifiers = ParseIdentifiers();
-    ASTUtils::Link(service_node, next_identifiers);
+  while (!tokens_.empty()) {
+    NodePtr<INode> identifier = ParseIdentifier();
+    ASTUtils::Link(service_node, identifier);
+
+    if (!tokens_.empty() && NodeDataClassifier::IsDot(PeekToken())) {
+      auto next_token = NextToken();
+      ValidateHasTokens("Missing identifier after the dot delimiter at line "
+                            + std::to_string(next_token->line));
+      ValidateIsWord(PeekToken());
+    } else {
+      break;
+    }
   }
 
   return service_node;
-}
-NodePtr<INode> Parser::ParseIdentifiers() {
-  auto next_token = NextToken();
-  NodePtr<INode> delimiter = ASTUtils::CreateServiceNode(StmtType::kDotDelimiter, next_token);
-
-  ValidateHasTokens("Missing identifier after the dot delimiter at line "
-                        + std::to_string(next_token->line));
-  NodePtr<INode> identifier = ParseIdentifier();
-  ASTUtils::Link(delimiter, identifier);
-
-  if (!tokens_.empty() && NodeDataClassifier::IsDot(PeekToken())) {
-    NodePtr<INode> next_identifiers = ParseIdentifiers();
-    ASTUtils::Link(delimiter, next_identifiers);
-  }
-
-  return delimiter;
 }
 NodePtr<INode> Parser::ParseIdentifier() {
   auto next_token = NextToken();

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -102,7 +102,7 @@ NodePtr<INode> Parser::ParseListOf(StmtType element_type) {
   }
   ASTUtils::Link(separator, next_element);
 
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+  if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
     NodePtr<INode> next_elements = ParseListOf(element_type);
     ASTUtils::Link(separator, next_elements);
   }
@@ -138,11 +138,11 @@ NodePtr<INode> Parser::ParsePrimaryKey() {
   ValidateIsOpeningRoundBracket(NextToken());
 
   ValidateHasTokens("Missed column name at line " + std::to_string(line));
-  while (!tokens_.empty()) {
+  while (HasTokens()) {
     NodePtr<INode> column_name = ParseColumnName();
     ASTUtils::Link(primary_key, column_name);
 
-    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+    if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       next_token = NextToken();
       ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
                             + ": missing column name after comma");
@@ -187,11 +187,11 @@ NodePtr<INode> Parser::ParseForeignKey() {
 
   ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
                         + ": missing referencing column name");
-  while (!tokens_.empty()) {
+  while (HasTokens()) {
     NodePtr<INode> referencing_column_name = ParseColumnName();
     ASTUtils::Link(foreign_key, referencing_column_name);
 
-    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+    if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       next_token = NextToken();
       ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
                             + ": missing referencing column name after comma");
@@ -229,16 +229,16 @@ NodePtr<INode> Parser::ParseReference() {
   NodePtr<INode> referenced_table_name = ParseTableName();
   ASTUtils::Link(reference, referenced_table_name);
 
-  if (!tokens_.empty() && NodeDataClassifier::IsOpeningRoundBracket(PeekToken())) {
+  if (HasTokens() && NodeDataClassifier::IsOpeningRoundBracket(PeekToken())) {
     next_token = NextToken();
 
     ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
                           + ": missing referenced column name");
-    while (!tokens_.empty()) {
+    while (HasTokens()) {
       NodePtr<INode> referenced_column_name = ParseColumnName();
       ASTUtils::Link(reference, referenced_column_name);
 
-      if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+      if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
         next_token = NextToken();
         ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
                               + ": missing referenced column name after comma");
@@ -323,11 +323,11 @@ NodePtr<INode> Parser::ParseString() {
 NodePtr<INode> Parser::ParseName() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kName, PeekToken());
 
-  while (!tokens_.empty()) {
+  while (HasTokens()) {
     NodePtr<INode> identifier = ParseIdentifier();
     ASTUtils::Link(service_node, identifier);
 
-    if (!tokens_.empty() && NodeDataClassifier::IsDot(PeekToken())) {
+    if (HasTokens() && NodeDataClassifier::IsDot(PeekToken())) {
       auto next_token = NextToken();
       ValidateHasTokens("Missing identifier after the dot delimiter at line "
                             + std::to_string(next_token->line));

--- a/src/parser/common/validation.cpp
+++ b/src/parser/common/validation.cpp
@@ -30,7 +30,7 @@ void Parser::ValidateHasTokens(unsigned min_count) const {
   }
 }
 void Parser::ValidateHasNotTokens() const {
-  if (!tokens_.empty()) {
+  if (HasTokens()) {
     throw parsing_error("Unexpected non empty tokens array");
   }
 }

--- a/src/parser/common/validation.cpp
+++ b/src/parser/common/validation.cpp
@@ -11,10 +11,21 @@ using NodePtr = std::shared_ptr<NodeType>;
 
 parsing_error::parsing_error(const std::string& message) : std::logic_error(message) {}
 
+bool Parser::HasTokens(unsigned min_count) const {
+  return tokens_.size() >= min_count;
+}
+
 void Parser::ValidateHasTokens(const std::string& details) const {
-  if (tokens_.empty()) {
+  if (!HasTokens()) {
     std::string msg = "Unexpected empty tokens array";
     std::string cause = (details.empty() ? "" : (": " + details));
+    throw parsing_error(msg + cause);
+  }
+}
+void Parser::ValidateHasTokens(unsigned min_count) const {
+  if (!HasTokens(min_count)) {
+    std::string msg = "Unexpected empty tokens array";
+    std::string cause = ": expected at least " + std::to_string(min_count) + " tokens";
     throw parsing_error(msg + cause);
   }
 }

--- a/src/parser/ddl/ddl_statements.cpp
+++ b/src/parser/ddl/ddl_statements.cpp
@@ -123,11 +123,11 @@ NodePtr<INode> Parser::ParseAlterTableStatement() {
 NodePtr<INode> Parser::ParseDropDatabaseStatement() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kDropDatabaseStmt);
 
-  while (!tokens_.empty()) {
+  while (HasTokens()) {
     NodePtr<INode> database_name = ParseName();
     ASTUtils::Link(service_node, database_name);
 
-    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+    if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
       ValidateHasTokens("Invalid \'DROP DATABASE\' statement at line "
                             + std::to_string(next_token->line)
@@ -143,11 +143,11 @@ NodePtr<INode> Parser::ParseDropDatabaseStatement() {
 NodePtr<INode> Parser::ParseDropTableStatement() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kDropTableStmt);
 
-  while (!tokens_.empty()) {
+  while (HasTokens()) {
     NodePtr<INode> table_name = ParseName();
     ASTUtils::Link(service_node, table_name);
 
-    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+    if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
       ValidateHasTokens("Invalid \'DROP TABLE\' statement at line "
                             + std::to_string(next_token->line)
@@ -166,11 +166,11 @@ NodePtr<INode> Parser::ParseTableDefinition() {
 
   NodePtr<INode> table_definition = ASTUtils::CreateServiceNode(StmtType::kTableDef);
 
-  while (!tokens_.empty()) {
+  while (HasTokens()) {
     NodePtr<INode> table_definition_element = ParseTableDefinitionElement();
     ASTUtils::Link(table_definition, table_definition_element);
 
-    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+    if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
       ValidateHasTokens("Invalid table definition at line " + std::to_string(next_token->line)
                             + ": expected column or constraint definition");
@@ -224,7 +224,7 @@ NodePtr<INode> Parser::ParseColumnDefinition() {
   NodePtr<INode> datatype = ParseDataType();
   ASTUtils::Link(service_node, datatype);
 
-  if (!tokens_.empty()) {
+  if (HasTokens()) {
     // TODO: parse options such as IDENTITY or (NOT) NULL.
   }
 
@@ -276,11 +276,11 @@ NodePtr<INode> Parser::ParseTableConstraint(StmtType stmt_type) {
 NodePtr<INode> Parser::ParseAlterAddListDefinition() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kAlterAddList);
 
-  while (!tokens_.empty()) {
+  while (HasTokens()) {
     NodePtr<INode> add_element = ParseAlterAddElement();
     ASTUtils::Link(service_node, add_element);
 
-    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+    if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
       ValidateHasTokens("Missing \'ALTER TABLE ... ADD\' element in list at line "
                             + std::to_string(next_token->line));
@@ -298,11 +298,11 @@ NodePtr<INode> Parser::ParseAlterAddElement() {
 NodePtr<INode> Parser::ParseAlterDropListDefinition() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kAlterDropList);
 
-  while (!tokens_.empty()) {
+  while (HasTokens()) {
     NodePtr<INode> drop_element = ParseAlterDropElement();
     ASTUtils::Link(service_node, drop_element);
 
-    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+    if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
       ValidateHasTokens("Missing \'ALTER TABLE ... DROP\' element in list at line "
                             + std::to_string(next_token->line));

--- a/src/parser/ddl/ddl_statements.cpp
+++ b/src/parser/ddl/ddl_statements.cpp
@@ -261,29 +261,20 @@ NodePtr<INode> Parser::ParseTableConstraint(StmtType stmt_type) {
 NodePtr<INode> Parser::ParseDropListDefinition() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kDropList);
 
-  NodePtr<INode> drop_element = ParseDropElement();
-  ASTUtils::Link(service_node, drop_element);
+  while (!tokens_.empty()) {
+    NodePtr<INode> drop_element = ParseDropElement();
+    ASTUtils::Link(service_node, drop_element);
 
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
-    NodePtr<INode> drop_elements = ParseDropElements();
-    ASTUtils::Link(service_node, drop_elements);
+    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+      auto next_token = NextToken();
+      ValidateHasTokens("Missing drop element in list at line " + std::to_string(next_token->line));
+      ValidateIsWord(PeekToken());
+    } else {
+      break;
+    }
   }
 
   return service_node;
-}
-NodePtr<INode> Parser::ParseDropElements() {
-  NodePtr<INode> separator = ASTUtils::CreateServiceNode(StmtType::kCommaDelimiter, NextToken());
-
-  ValidateIsWord(PeekToken());
-  NodePtr<INode> drop_element = ParseDropElement();
-  ASTUtils::Link(separator, drop_element);
-
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
-      NodePtr<INode> drop_elements = ParseDropElements();
-      ASTUtils::Link(separator, drop_elements);
-  }
-
-  return separator;
 }
 NodePtr<INode> Parser::ParseDropElement() {
   auto next_token = NextToken();
@@ -295,10 +286,11 @@ NodePtr<INode> Parser::ParseDropElement() {
   auto peeked_token = PeekToken();
   NodePtr<INode> argument;
   switch (drop_element_type) {
-    case StmtType::kColumnKW:
+    case StmtType::kDropColumn:
+      ValidateIsWord(peeked_token);
       argument = ParseName();
       break;
-    case StmtType::kConstraintKW:
+    case StmtType::kDropConstraint:
       argument = ParseTableConstraint();
       break;
     default:
@@ -307,12 +299,13 @@ NodePtr<INode> Parser::ParseDropElement() {
   }
   ASTUtils::Link(drop_element, argument);
 
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(peeked_token)) {
+  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
     // TODO: check that we have at least 2 tokens.
     if (NodeDataTypeClassifier::IsWord(tokens_[1])) {
       std::string checking_word = ASTUtils::CastToNodeType<StringNode>(tokens_[1])->data;
       if (DetermineDropElementType(checking_word) == StmtType::kNone) {
-        NodePtr<INode> next_arguments = ParseListOf(StmtType::kIdentifier);
+        // TODO: COLUMN keyword is recognized as an identifier. Ignore keywords in ParseListOf.
+        NodePtr<INode> next_arguments = ParseListOf(StmtType::kName);
         ASTUtils::Link(drop_element, next_arguments);
       }
     }

--- a/src/parser/ddl/ddl_statements.cpp
+++ b/src/parser/ddl/ddl_statements.cpp
@@ -327,30 +327,44 @@ NodePtr<INode> Parser::ParseAlterDropElement() {
   switch (drop_element_type) {
     case StmtType::kDropColumn:
       ValidateIsWord(peeked_token);
-      argument = ParseName();
+      ParseAlterDropColumns(drop_element);
       break;
     case StmtType::kDropConstraint:
       argument = ParseTableConstraint();
+      ASTUtils::Link(drop_element, argument);
       break;
     default:
       throw parsing_error("Unknown \'ALTER TABLE ... DROP\' element type at line "
                               + std::to_string(peeked_token->line));
   }
-  ASTUtils::Link(drop_element, argument);
-
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
-    // TODO: check that we have at least 2 tokens.
-    if (NodeDataTypeClassifier::IsWord(tokens_[1])) {
-      std::string checking_word = ASTUtils::CastToNodeType<StringNode>(tokens_[1])->data;
-      if (DetermineDropElementType(checking_word) == StmtType::kNone) {
-        // TODO: COLUMN keyword is recognized as an identifier. Ignore keywords in ParseListOf.
-        NodePtr<INode> next_arguments = ParseListOf(StmtType::kName);
-        ASTUtils::Link(drop_element, next_arguments);
-      }
-    }
-  }
 
   return drop_element;
+}
+void Parser::ParseAlterDropColumns(NodePtr<INode>& parent) {
+  auto has_next_column_name_node = [this]() {
+    if (HasTokens(2) && NodeDataClassifier::IsComma(PeekToken())) {
+      auto peeked_token = PeekToken(1);
+      if (NodeDataTypeClassifier::IsWord(peeked_token)) {
+        std::string checking_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
+        return DetermineDropElementType(checking_word) == StmtType::kNone;
+      }
+    }
+    return false;
+  };
+
+  while (HasTokens()) {
+    auto column_name_node = ParseName();
+    ASTUtils::Link(parent, column_name_node);
+
+    if (!has_next_column_name_node()) {
+      break;
+    }
+
+    auto next_token = NextToken();
+    ValidateHasTokens("Missing column name after comma at line "
+                          + std::to_string(next_token->line));
+    ValidateIsWord(PeekToken());
+  }
 }
 
 } // scc::parser

--- a/src/parser/ddl/ddl_statements.cpp
+++ b/src/parser/ddl/ddl_statements.cpp
@@ -104,10 +104,10 @@ NodePtr<INode> Parser::ParseAlterTableStatement() {
   StmtType action_type = DetermineAlterTableActionType(action_keyword);
   switch (action_type) {
     case StmtType::kAddKW:
-      argument = ParseTableDefinitionElements();
+      argument = ParseAlterAddListDefinition();
       break;
     case StmtType::kDropKW:
-      argument = ParseDropListDefinition();
+      argument = ParseAlterDropListDefinition();
       break;
     default:
       line = PeekToken()->line;
@@ -150,25 +150,26 @@ NodePtr<INode> Parser::ParseDropTableStatement() {
 NodePtr<INode> Parser::ParseTableDefinition() {
   ValidateIsOpeningRoundBracket(NextToken());
 
-  NodePtr<INode> table_definition = ParseTableDefinitionElements();
+  NodePtr<INode> table_definition = ASTUtils::CreateServiceNode(StmtType::kTableDef);
+
+  while (!tokens_.empty()) {
+    NodePtr<INode> table_definition_element = ParseTableDefinitionElement();
+    ASTUtils::Link(table_definition, table_definition_element);
+
+    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+      auto next_token = NextToken();
+      ValidateHasTokens("Invalid table definition at line " + std::to_string(next_token->line)
+                            + ": expected column or constraint definition");
+      ValidateIsWord(PeekToken());
+    } else {
+      break;
+    }
+  }
 
   ValidateHasTokens("Missing closing round bracket at line "); // TODO: add line number
   ValidateIsClosingRoundBracket(NextToken());
 
   return table_definition;
-}
-NodePtr<INode> Parser::ParseTableDefinitionElements() {
-  NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kTableDef);
-
-  NodePtr<INode> first_element = ParseTableDefinitionElement();
-  ASTUtils::Link(service_node, first_element);
-
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
-    NodePtr<INode> separator = ParseListOf(StmtType::kTableDef);
-    ASTUtils::Link(service_node, separator);
-  }
-
-  return service_node;
 }
 NodePtr<INode> Parser::ParseTableDefinitionElement() {
   auto peeked_token = PeekToken();
@@ -258,16 +259,17 @@ NodePtr<INode> Parser::ParseTableConstraint(StmtType stmt_type) {
   return service_node;
 }
 
-NodePtr<INode> Parser::ParseDropListDefinition() {
-  NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kDropList);
+NodePtr<INode> Parser::ParseAlterAddListDefinition() {
+  NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kAlterAddList);
 
   while (!tokens_.empty()) {
-    NodePtr<INode> drop_element = ParseDropElement();
-    ASTUtils::Link(service_node, drop_element);
+    NodePtr<INode> add_element = ParseAlterAddElement();
+    ASTUtils::Link(service_node, add_element);
 
     if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
-      ValidateHasTokens("Missing drop element in list at line " + std::to_string(next_token->line));
+      ValidateHasTokens("Missing \'ALTER TABLE ... ADD\' element in list at line "
+                            + std::to_string(next_token->line));
       ValidateIsWord(PeekToken());
     } else {
       break;
@@ -276,13 +278,36 @@ NodePtr<INode> Parser::ParseDropListDefinition() {
 
   return service_node;
 }
-NodePtr<INode> Parser::ParseDropElement() {
+NodePtr<INode> Parser::ParseAlterAddElement() {
+  return ParseTableDefinitionElement();
+}
+NodePtr<INode> Parser::ParseAlterDropListDefinition() {
+  NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kAlterDropList);
+
+  while (!tokens_.empty()) {
+    NodePtr<INode> drop_element = ParseAlterDropElement();
+    ASTUtils::Link(service_node, drop_element);
+
+    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+      auto next_token = NextToken();
+      ValidateHasTokens("Missing \'ALTER TABLE ... DROP\' element in list at line "
+                            + std::to_string(next_token->line));
+      ValidateIsWord(PeekToken());
+    } else {
+      break;
+    }
+  }
+
+  return service_node;
+}
+NodePtr<INode> Parser::ParseAlterDropElement() {
   auto next_token = NextToken();
   std::string keyword = ASTUtils::CastToNodeType<StringNode>(next_token)->data;
   StmtType drop_element_type = DetermineDropElementType(keyword);
   NodePtr<INode> drop_element = ASTUtils::CreateServiceNode(drop_element_type);
 
-  ValidateHasTokens("Missing drop element definition at line " + std::to_string(next_token->line));
+  ValidateHasTokens("Missing \'ALTER TABLE ... DROP\' element definition at line "
+                        + std::to_string(next_token->line));
   auto peeked_token = PeekToken();
   NodePtr<INode> argument;
   switch (drop_element_type) {
@@ -294,7 +319,7 @@ NodePtr<INode> Parser::ParseDropElement() {
       argument = ParseTableConstraint();
       break;
     default:
-      throw parsing_error("Unknown drop element type at line "
+      throw parsing_error("Unknown \'ALTER TABLE ... DROP\' element type at line "
                               + std::to_string(peeked_token->line));
   }
   ASTUtils::Link(drop_element, argument);

--- a/src/parser/ddl/ddl_statements.cpp
+++ b/src/parser/ddl/ddl_statements.cpp
@@ -123,12 +123,19 @@ NodePtr<INode> Parser::ParseAlterTableStatement() {
 NodePtr<INode> Parser::ParseDropDatabaseStatement() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kDropDatabaseStmt);
 
-  NodePtr<INode> database_name = ParseName();
-  ASTUtils::Link(service_node, database_name);
+  while (!tokens_.empty()) {
+    NodePtr<INode> database_name = ParseName();
+    ASTUtils::Link(service_node, database_name);
 
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
-    NodePtr<INode> names_list = ParseListOf(StmtType::kName);
-    ASTUtils::Link(service_node, names_list);
+    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+      auto next_token = NextToken();
+      ValidateHasTokens("Invalid \'DROP DATABASE\' statement at line "
+                            + std::to_string(next_token->line)
+                            + ": expected database name after comma");
+      ValidateIsWord(PeekToken());
+    } else {
+      break;
+    }
   }
 
   return service_node;
@@ -136,12 +143,19 @@ NodePtr<INode> Parser::ParseDropDatabaseStatement() {
 NodePtr<INode> Parser::ParseDropTableStatement() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kDropTableStmt);
 
-  NodePtr<INode> table_name = ParseName();
-  ASTUtils::Link(service_node, table_name);
+  while (!tokens_.empty()) {
+    NodePtr<INode> table_name = ParseName();
+    ASTUtils::Link(service_node, table_name);
 
-  if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
-    NodePtr<INode> names_list = ParseListOf(StmtType::kName);
-    ASTUtils::Link(service_node, names_list);
+    if (!tokens_.empty() && NodeDataClassifier::IsComma(PeekToken())) {
+      auto next_token = NextToken();
+      ValidateHasTokens("Invalid \'DROP TABLE\' statement at line "
+                            + std::to_string(next_token->line)
+                            + ": expected table name after comma");
+      ValidateIsWord(PeekToken());
+    } else {
+      break;
+    }
   }
 
   return service_node;

--- a/src/parser/dml/conditions.cpp
+++ b/src/parser/dml/conditions.cpp
@@ -22,7 +22,7 @@ NodePtr<INode> Parser::ParseORCondition() {
   ASTUtils::Link(service_node, and_condition);
 
   auto peeked_token = PeekToken();
-  if (!tokens_.empty() && NodeDataTypeClassifier::IsWord(peeked_token)) {
+  if (HasTokens() && NodeDataTypeClassifier::IsWord(peeked_token)) {
     std::string checking_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
     if (DetermineIsOROperator(checking_word)) {
       NextToken();
@@ -41,7 +41,7 @@ NodePtr<INode> Parser::ParseANDCondition() {
   ASTUtils::Link(service_node, not_condition);
 
   auto peeked_token = PeekToken();
-  if (!tokens_.empty() && NodeDataTypeClassifier::IsWord(peeked_token)) {
+  if (HasTokens() && NodeDataTypeClassifier::IsWord(peeked_token)) {
     std::string checking_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
     if (DetermineIsANDOperator(checking_word)) {
       NextToken();

--- a/src/parser/dml/math_expressions.cpp
+++ b/src/parser/dml/math_expressions.cpp
@@ -27,7 +27,7 @@ NodePtr<INode> Parser::ParseMathExpression() {
 NodePtr<INode> Parser::ParseMathSum() {
   NodePtr<INode> lhs_product = ParseMathProduct();
 
-  if (!tokens_.empty() && NodeDataTypeClassifier::IsOperator(PeekToken())) {
+  if (HasTokens() && NodeDataTypeClassifier::IsOperator(PeekToken())) {
     NodePtr<INode> operator_node = PeekToken();
     std::string operator_str = ASTUtils::CastToNodeType<StringNode>(operator_node)->data;
     if (operator_str == "+" || operator_str == "-") {
@@ -48,7 +48,7 @@ NodePtr<INode> Parser::ParseMathSum() {
 NodePtr<INode> Parser::ParseMathProduct() {
   NodePtr<INode> lhs_power = ParseMathPower();
 
-  if (!tokens_.empty() && NodeDataTypeClassifier::IsOperator(PeekToken())) {
+  if (HasTokens() && NodeDataTypeClassifier::IsOperator(PeekToken())) {
     NodePtr<INode> operator_node = PeekToken();
     std::string operator_str = ASTUtils::CastToNodeType<StringNode>(operator_node)->data;
     if (operator_str == "*" || operator_str == "/") {
@@ -69,7 +69,7 @@ NodePtr<INode> Parser::ParseMathProduct() {
 NodePtr<INode> Parser::ParseMathPower() {
   NodePtr<INode> value = ParseMathValue();
 
-  if (!tokens_.empty() && NodeDataTypeClassifier::IsOperator(PeekToken())) {
+  if (HasTokens() && NodeDataTypeClassifier::IsOperator(PeekToken())) {
     NodePtr<INode> operator_node = PeekToken();
     std::string operator_str = ASTUtils::CastToNodeType<StringNode>(operator_node)->data;
     if (operator_str == "^") {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -20,12 +20,14 @@ NodePtr<INode> Parser::Parse() {
   }
 
   NodePtr<INode> root = ASTUtils::CreateRootNode(StmtType::kProgram);
-  NodePtr<INode> query = ParseQuery();
-  ASTUtils::Link(root, query);
+  while (!tokens_.empty()) {
+    if (NodeDataClassifier::IsSemicolon(PeekToken())) {
+      NextToken();
+      continue;
+    }
 
-  if (!tokens_.empty() && NodeDataClassifier::IsSemicolon(PeekToken())) {
-    NodePtr<INode> next_queries = ParseNextQueries();
-    ASTUtils::Link(root, next_queries);
+    NodePtr<INode> query = ParseQuery();
+    ASTUtils::Link(root, query);
   }
 
   ValidateHasNotTokens();
@@ -65,22 +67,6 @@ NodePtr<INode> Parser::ParseBaseStatement() {
   } else {
     throw parsing_error("Unknown Base Statement at line " + std::to_string(peeked_token->line));
   }
-}
-NodePtr<INode> Parser::ParseNextQueries() {
-  NodePtr<INode> separator = ASTUtils::CreateServiceNode(StmtType::kSemicolonDelimiter,
-                                                         NextToken());
-
-  if (!tokens_.empty()) {
-    NodePtr<INode> query = ParseQuery();
-    ASTUtils::Link(separator, query);
-  }
-
-  if (!tokens_.empty() && NodeDataClassifier::IsSemicolon(PeekToken())) {
-    NodePtr<INode> next_queries = ParseNextQueries();
-    ASTUtils::Link(separator, next_queries);
-  }
-
-  return separator;
 }
 
 } // scc::parser

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -35,12 +35,12 @@ NodePtr<INode> Parser::Parse() {
   return root;
 }
 
-const NodePtr<INode>& Parser::PeekToken() const {
-  ValidateHasTokens();
-  return tokens_.front();
+const NodePtr<INode>& Parser::PeekToken(unsigned idx) const {
+  ValidateHasTokens(idx + 1);
+  return tokens_[idx];
 }
 NodePtr<INode> Parser::NextToken() {
-  ValidateHasTokens();
+  ValidateHasTokens(1);
   NodePtr<INode> node = tokens_.front();
   tokens_.pop_front();
   return node;

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -14,13 +14,13 @@ Parser::Parser(std::deque<NodePtr<INode>>&& tokens) : tokens_(std::move(tokens))
 
 NodePtr<INode> Parser::Parse() {
   LOGI << "Parsing is started";
-  if (tokens_.empty()) {
+  if (!HasTokens()) {
     LOGI << "Parsing is finished. Nothing to parse";
     return {};
   }
 
   NodePtr<INode> root = ASTUtils::CreateRootNode(StmtType::kProgram);
-  while (!tokens_.empty()) {
+  while (HasTokens()) {
     if (NodeDataClassifier::IsSemicolon(PeekToken())) {
       NextToken();
       continue;

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -13,46 +13,32 @@ using NodePtr = std::shared_ptr<NodeType>;
 void Translator::TranslatePrimaryKey(const NodePtr<INode>& primary_key,
                                      const std::string& constraint_name,
                                      const std::string& table_name) {
-  auto column_name_node = primary_key->Child(0);
-  ValidateHasChildren(column_name_node);
-  auto column_name = GetName(column_name_node);
+  for (unsigned i = 0; HasChildren(primary_key, i + 1); ++i) {
+    auto column_name_node = primary_key->Child(i);
+    ValidateHasChildren(column_name_node);
+    auto column_name = GetName(column_name_node);
 
-  std::vector<std::string> properties;
-  properties.push_back(column_name);
-
-  if (HasChildren(primary_key, 2)) {
-    auto other_column_name_node = primary_key->Child(1);
-    ValidateHasChildren(other_column_name_node);
-    std::vector<std::string> other_properties = GetList(other_column_name_node, StmtType::kName);
-    properties.insert(properties.end(), other_properties.begin(), other_properties.end());
-  }
-
-  for (const auto& property: properties) {
     CreateConstraint(constraint_name + "_" + std::to_string(constraint_counter++), table_name,
-                        property, ConstraintType::kUniqueness);
+                     column_name, ConstraintType::kUniqueness);
     CreateConstraint(constraint_name + "_" + std::to_string(constraint_counter++), table_name,
-                        property, ConstraintType::kExistence);
+                     column_name, ConstraintType::kExistence);
   }
 }
 void Translator::TranslateForeignKey(const NodePtr<INode>& foreign_key,
                                      const std::string& table_name) {
-  auto column_name_node = foreign_key->Child(0);
-  ValidateHasChildren(column_name_node);
-  auto column_name = GetName(column_name_node);
-
   std::vector<std::string> properties;
-  properties.push_back(column_name);
-
-  int reference_child_num = 1;
-  if (HasChildren(foreign_key, 3)) {
-    reference_child_num++;
-    auto separator_node = foreign_key->Child(1);
-    ValidateIsCorrectStmtType(separator_node, StmtType::kCommaDelimiter);
-    std::vector<std::string> other_properties = GetList(separator_node, StmtType::kName);
-    properties.insert(properties.end(), other_properties.begin(), other_properties.end());
+  for (unsigned i = 0; HasChildren(foreign_key, i + 1); ++i) {
+    auto column_name_node = foreign_key->Child(i);
+    if (!IsCorrectStmtType(column_name_node, StmtType::kName)) {
+      break;
+    }
+    ValidateHasChildren(column_name_node);
+    auto column_name = GetName(column_name_node);
+    properties.push_back(column_name);
   }
 
-  auto reference = foreign_key->Child(reference_child_num);
+  ValidateHasChildren(foreign_key, properties.size() + 1);
+  auto reference = foreign_key->Child(properties.size());
   ValidateIsCorrectStmtType(reference, StmtType::kReferencesKW);
 
   ValidateHasChildren(reference);
@@ -62,16 +48,14 @@ void Translator::TranslateForeignKey(const NodePtr<INode>& foreign_key,
   std::string ref_table_name = GetName(table_name_node);
 
   std::vector<std::string> ref_columns;
-  if (HasChildren(reference, 2)) {
-    auto ref_column_name_node = reference->Child(1);
-    ValidateHasChildren(ref_column_name_node);
-    ref_columns.push_back(GetName(ref_column_name_node));
-    if (HasChildren(reference, 3)) {
-      auto other_ref_column_name_node = reference->Child(2);
-      ValidateHasChildren(other_ref_column_name_node);
-      std::vector<std::string> other_props = GetList(other_ref_column_name_node, StmtType::kName);
-      ref_columns.insert(ref_columns.end(), other_props.begin(), other_props.end());
+  for (unsigned i = 1; HasChildren(reference, i + 1); ++i) {
+    auto ref_column_name_node = reference->Child(i);
+    if (!IsCorrectStmtType(ref_column_name_node, StmtType::kName)) {
+      break;
     }
+    ValidateHasChildren(ref_column_name_node);
+    auto column_name = GetName(ref_column_name_node);
+    ref_columns.push_back(column_name);
   }
 
   // TODO: Match all nodes with correspond labels and remove properties.

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -68,32 +68,6 @@ void Translator::TranslateForeignKey(const NodePtr<INode>& foreign_key,
   CreateRelationship(table_name, ref_table_name);
 }
 
-std::vector<std::string> Translator::GetList(const NodePtr<INode>& node, StmtType type) const {
-  auto argument_node = node->Child(0);
-  ValidateHasChildren(argument_node);
-  std::vector<std::string> arguments;
-  std::string argument;
-  switch (type) {
-    case StmtType::kName:
-      argument = GetName(argument_node);
-      break;
-    case StmtType::kIdentifier:
-      argument = GetIdentifier(argument_node);
-      break;
-    default:
-      throw translation_error("Unknown argument type for list of elements");
-  }
-  arguments.push_back(argument);
-
-  if (HasChildren(node, 2)) {
-    auto next_separator_node = node->Child(1);
-    ValidateHasChildren(next_separator_node);
-    std::vector<std::string> other_arguments = GetList(next_separator_node, type);
-    arguments.insert(arguments.end(), other_arguments.begin(), other_arguments.end());
-  }
-
-  return arguments;
-}
 std::string Translator::GetName(const NodePtr<INode>& name_node) const {
   std::ostringstream name;
   ValidateHasChildren(name_node);

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -110,37 +110,15 @@ std::vector<std::string> Translator::GetList(const NodePtr<INode>& node, StmtTyp
 
   return arguments;
 }
-std::string Translator::GetName(const NodePtr<INode>& node) const {
-  auto identifier_node = node->Child(0);
-  ValidateHasChildren(identifier_node);
-
+std::string Translator::GetName(const NodePtr<INode>& name_node) const {
   std::ostringstream name;
-  name << GetIdentifier(identifier_node);
-
-  if (HasChildren(node, 2)) {
-    auto dot_delimiter_node = node->Child(1);
-    ValidateHasChildren(dot_delimiter_node);
-    ValidateIsCorrectStmtType(dot_delimiter_node, StmtType::kDotDelimiter);
-    name << GetIdentifiersJoinedByDot(dot_delimiter_node);
+  ValidateHasChildren(name_node);
+  for (unsigned i = 0; HasChildren(name_node, i + 1); ++i) {
+    auto identifier_node = name_node->Child(i);
+    auto identifier = GetIdentifier(identifier_node);
+    name << identifier;
   }
-
   return name.str();
-}
-std::string Translator::GetIdentifiersJoinedByDot(const NodePtr<INode>& node) const {
-  auto identifier_node = node->Child(0);
-  ValidateHasChildren(identifier_node);
-
-  std::ostringstream identifiers;
-  identifiers << "." << GetIdentifier(identifier_node);
-
-  if (HasChildren(node, 2)) {
-    auto dot_delimiter_node = node->Child(1);
-    ValidateHasChildren(dot_delimiter_node);
-    ValidateIsCorrectStmtType(dot_delimiter_node, StmtType::kIdentifier);
-    identifiers << GetIdentifiersJoinedByDot(dot_delimiter_node);
-  }
-
-  return identifiers.str();
 }
 std::string Translator::GetIdentifier(const NodePtr<INode>& node) const {
   return ASTUtils::CastToNodeType<StringNode>(node->Child(0))->data;

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -168,7 +168,7 @@ void Translator::CreateRelationship(const std::string& start_label_name,
   WriteCypherQuery(CreateRelationshipClauseBuilder::Build(relationship));
 }
 void Translator::RemoveProperty(const std::string& label_name, const std::string& property_name) {
-  Node node(label_name);
+  Node node(label_name, "n");
   WriteCypherQuery(RemovePropertyClauseBuilder::Build(node, property_name));
 }
 std::string Translator::CreateRelationshipType(const std::string& start_label_name,

--- a/src/translator/cypher/clauses/set.cpp
+++ b/src/translator/cypher/clauses/set.cpp
@@ -11,11 +11,6 @@ std::string SetPropertyClauseBuilder::Build(const Node& node, const NodeProperty
 }
 
 std::string RemovePropertyClauseBuilder::Build(const Node& node, const std::string& property_name) {
-  if (!node.HasProperty(property_name)) {
-    throw std::invalid_argument("Could not build Remove Property clause: property \'"
-                                    + property_name + " does not exist on node \'" + node.ToString()
-                                    + "\'");
-  }
   std::stringstream ss;
   ss << "MATCH " << node.ToString() << "\n";
   ss << "SET " << node.variable << "." << property_name << " = null";

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -59,6 +59,9 @@ bool Node::HasProperty(const std::string& name) const {
   static auto predicate = [name](const NodeProperty& property) { return property.name == name; };
   return std::find_if(properties.begin(), properties.end(), predicate) != properties.end();
 }
+unsigned Node::PropertyCount() const {
+  return properties.size();
+}
 Node& Node::AddLabel(const Label& label) {
   labels.push_back(label);
   return *this;

--- a/src/translator/ddl/ddl_statements.cpp
+++ b/src/translator/ddl/ddl_statements.cpp
@@ -45,39 +45,24 @@ void Translator::TranslateCreateTableStatement(const NodePtr<INode>& stmt) {
   auto table_name_node = stmt->Child(0);
   ValidateHasChildren(table_name_node);
   std::string table_name = GetName(table_name_node);
-  Node node(table_name);
 
   ValidateHasChildren(stmt, 2, "Missing table definition" + msg_suffix);
   auto table_definition = stmt->Child(1);
 
+  Node node(table_name);
   ValidateHasChildren(table_definition, 1, "Empty table definition" + msg_suffix);
-  auto column_definition = table_definition->Child(0);
-
-  ValidateIsCorrectStmtType(column_definition, StmtType::kColumnDef);
-  NodeProperty first_property = TranslateColumnDefinition(column_definition);
-  node.AddProperty(first_property);
-
-  if (HasChildren(table_definition, 2)) {
-    auto comma = table_definition->Child(1);
-    ValidateIsCorrectStmtType(comma, StmtType::kCommaDelimiter);
-    ValidateHasChildren(comma, 1, "Invalid table definition" + msg_suffix
-        + ": comma without next element");
-
-    if (IsCorrectStmtType(comma->Child(0), StmtType::kColumnDef)) {
-      std::vector<NodeProperty> other_props = TranslateColumnDefinitions(comma);
-      for (auto& prop: other_props) {
-        node.AddProperty(prop);
-      }
+  auto table_definition_element = table_definition->Child(0);
+  if (IsCorrectStmtType(table_definition_element, StmtType::kColumnDef)) {
+    std::vector<NodeProperty> properties = TranslateColumnDefinitions(table_definition);
+    for (auto& property: properties) {
+      node.AddProperty(property);
     }
   }
-
   WriteCypherQuery(CreateNodeClauseBuilder::Build(node));
 
-  if (HasChildren(table_definition, 2)) {
-    auto constraints = FindConstraint(table_definition->Child(1));
-    if (constraints != nullptr) {
-      TranslateListOfTableConstraints(constraints, table_name);
-    }
+  for (unsigned i = node.PropertyCount(); HasChildren(table_definition, i + 1); ++i) {
+    auto constraint_definition = table_definition->Child(i);
+    TranslateTableConstraint(constraint_definition, table_name);
   }
 }
 void Translator::TranslateAlterTableStatement(const NodePtr<INode>& stmt) {
@@ -138,33 +123,20 @@ void Translator::TranslateAlterTableActionAdd(const NodePtr<INode>& action_node,
 
   auto table_definition = action_node->Child(0);
 
+  Node node(table_name, "n");
   ValidateHasChildren(table_definition, 1, "Missing column definition or constraint" + msg_suffix);
-  auto first_argument = table_definition->Child(0);
-
-  if (IsCorrectStmtType(first_argument, StmtType::kColumnDef)) {
-    Node node(table_name, "n");
-
-    NodeProperty first_prop = TranslateColumnDefinition(first_argument);
-    WriteCypherQuery(SetPropertyClauseBuilder::Build(node, first_prop));
-
-    if (HasChildren(table_definition, 2)) {
-      auto comma = table_definition->Child(1);
-      ValidateIsCorrectStmtType(comma, StmtType::kCommaDelimiter);
-
-      if (IsCorrectStmtType(comma->Child(0), StmtType::kColumnDef)) {
-        std::vector<NodeProperty> other_props = TranslateColumnDefinitions(comma);
-        for (auto& prop: other_props) {
-          WriteCypherQuery(SetPropertyClauseBuilder::Build(node, prop));
-        }
-      }
+  auto add_element = table_definition->Child(0);
+  if (IsCorrectStmtType(add_element, StmtType::kColumnDef)) {
+    std::vector<NodeProperty> properties = TranslateColumnDefinitions(table_definition);
+    for (auto& property: properties) {
+      WriteCypherQuery(SetPropertyClauseBuilder::Build(node, property));
+      node.AddProperty(property);
     }
+  }
 
-    auto constraints = FindConstraint(table_definition->Child(1));
-    if (constraints != nullptr) {
-      TranslateListOfTableConstraints(constraints, table_name);
-    }
-  } else {
-    TranslateListOfTableConstraints(table_definition, table_name);
+  for (unsigned i = node.PropertyCount(); HasChildren(table_definition, i + 1); ++i) {
+    auto constraint_definition = table_definition->Child(i);
+    TranslateTableConstraint(constraint_definition, table_name);
   }
 }
 void Translator::TranslateAlterTableActionDrop(const NodePtr<INode>& action_node,
@@ -185,23 +157,20 @@ void Translator::TranslateAlterTableActionDrop(const NodePtr<INode>& action_node
   }
 }
 
-std::vector<NodeProperty> Translator::TranslateColumnDefinitions(
-    const NodePtr<INode>& column_definition) {
-  auto argument = column_definition->Child(0);
-  ValidateIsCorrectStmtType(argument, StmtType::kColumnDef);
+std::vector<NodeProperty> Translator::TranslateColumnDefinitions(const NodePtr<INode>& node) {
+  std::vector<NodeProperty> properties;
 
-  ValidateHasChildren(argument);
-  std::vector<NodeProperty> column_definitions;
-  column_definitions.push_back(TranslateColumnDefinition(argument));
-  if (HasChildren(column_definition, 2)) {
-    auto comma = column_definition->Child(1);
-    if (IsCorrectStmtType(comma->Child(0), StmtType::kColumnDef)) {
-      std::vector<NodeProperty> other_cols = TranslateColumnDefinitions(comma);
-      column_definitions.insert(column_definitions.end(), other_cols.begin(), other_cols.end());
+  for (unsigned i = 0; HasChildren(node, i + 1); ++i) {
+    auto column_definition = node->Child(i);
+    if (!IsCorrectStmtType(column_definition, StmtType::kColumnDef)) {
+      break;
     }
+    ValidateHasChildren(column_definition);
+    NodeProperty property = TranslateColumnDefinition(column_definition);
+    properties.push_back(property);
   }
 
-  return column_definitions;
+  return properties;
 }
 NodeProperty Translator::TranslateColumnDefinition(const NodePtr<INode>& node) {
   auto column_name_node = node->Child(0);
@@ -233,18 +202,16 @@ NodeProperty Translator::TranslateColumnDefinition(const NodePtr<INode>& node) {
 
   return NodeProperty(column_name, datatype_str, property_type);
 }
-
-void Translator::TranslateListOfTableConstraints(const NodePtr<INode>& node,
-                                                 std::string& table_name) {
-  auto constraint = node->Child(0);
-  ValidateHasChildren(constraint, 1, "Missing constraint definition");
+void Translator::TranslateTableConstraint(const NodePtr<INode>& constraint_definition,
+                                          const std::string& table_name) {
+  ValidateHasChildren(constraint_definition, 1, "Missing constraint definition");
 
   size_t key_node_number = 0;
   std::string constraint_name;
-  if (HasChildren(constraint, 2)) {
+  if (HasChildren(constraint_definition, 2)) {
     key_node_number++;
 
-    auto constraint_kw = constraint->Child(0);
+    auto constraint_kw = constraint_definition->Child(0);
     ValidateIsCorrectStmtType(constraint_kw, StmtType::kConstraintKW);
     ValidateHasChildren(constraint_kw);
     constraint_name += GetIdentifier(constraint_kw->Child(0));
@@ -252,8 +219,8 @@ void Translator::TranslateListOfTableConstraints(const NodePtr<INode>& node,
     constraint_name = table_name + "_constraint";
   }
 
-  ValidateHasChildren(constraint, key_node_number, "Missing constraint definition");
-  auto key = constraint->Child(key_node_number);
+  ValidateHasChildren(constraint_definition, key_node_number, "Missing constraint definition");
+  auto key = constraint_definition->Child(key_node_number);
   ValidateHasChildren(key);
   switch (key->stmt_type) {
     case StmtType::kPrimaryKey:
@@ -265,31 +232,10 @@ void Translator::TranslateListOfTableConstraints(const NodePtr<INode>& node,
     default:
       throw translation_error("Unknown constraint type \'" + key->stmt_type.ToString() + "\'");
   }
-
-  if (HasChildren(node, 2)) {
-    TranslateListOfTableConstraints(node->Child(1), table_name);
-  }
-}
-std::shared_ptr<INode> Translator::FindConstraint(const NodePtr<INode>& node) {
-  std::shared_ptr<INode> constraints = nullptr;
-  if (!HasChildren(node)) {
-    return constraints;
-  }
-
-  auto left = node->Child(0);
-  if (IsCorrectStmtType(left, StmtType::kTableConstraint)) {
-    constraints = node;
-  } else {
-    if (HasChildren(node, 2)) {
-      constraints = FindConstraint(node->Child(1));
-    }
-  }
-
-  return constraints;
 }
 
 void Translator::TranslateDropElements(const NodePtr<INode>& node, std::string& table_name) {
-  ValidateIsCorrectStmtType(node, StmtType::kDropList);
+  ValidateIsCorrectStmtType(node, StmtType::kAlterDropList);
   for (unsigned i = 0; HasChildren(node, i + 1); ++i) {
     auto drop_object = node->Child(0);
     ValidateHasChildren(drop_object);

--- a/src/translator/ddl/ddl_statements.cpp
+++ b/src/translator/ddl/ddl_statements.cpp
@@ -206,9 +206,9 @@ void Translator::TranslateTableConstraint(const NodePtr<INode>& constraint_defin
                                           const std::string& table_name) {
   ValidateHasChildren(constraint_definition, 1, "Missing constraint definition");
 
-  size_t key_node_number = 0;
+  size_t key_node_number = 1;
   std::string constraint_name;
-  if (HasChildren(constraint_definition, 2)) {
+  if (HasChildren(constraint_definition, key_node_number + 1)) {
     key_node_number++;
 
     auto constraint_kw = constraint_definition->Child(0);
@@ -220,7 +220,7 @@ void Translator::TranslateTableConstraint(const NodePtr<INode>& constraint_defin
   }
 
   ValidateHasChildren(constraint_definition, key_node_number, "Missing constraint definition");
-  auto key = constraint_definition->Child(key_node_number);
+  auto key = constraint_definition->Child(key_node_number - 1);
   ValidateHasChildren(key);
   switch (key->stmt_type) {
     case StmtType::kPrimaryKey:

--- a/src/translator/ddl/ddl_statements.cpp
+++ b/src/translator/ddl/ddl_statements.cpp
@@ -88,32 +88,22 @@ void Translator::TranslateAlterTableStatement(const NodePtr<INode>& stmt) {
   }
 }
 void Translator::TranslateDropDatabaseStatement(const NodePtr<INode>& stmt) {
-  auto database_name_node = stmt->Child(0);
-  ValidateHasChildren(database_name_node);
-  auto database_name = GetName(database_name_node);
-  WriteCypherQuery(DropDatabaseClauseBuilder::Build(database_name));
+  for (unsigned i = 0; HasChildren(stmt, i + 1); ++i) {
+    auto database_name_node = stmt->Child(i);
+    ValidateHasChildren(database_name_node);
+    auto database_name = GetName(database_name_node);
 
-  if (HasChildren(stmt, 2)) {
-    std::vector<std::string> other_db_names = GetList(stmt->Child(1), StmtType::kName);
-    for (const auto& other_database_name: other_db_names) {
-      WriteCypherQuery(DropDatabaseClauseBuilder::Build(other_database_name));
-    }
+    WriteCypherQuery(DropDatabaseClauseBuilder::Build(database_name));
   }
 }
 void Translator::TranslateDropTableStatement(const NodePtr<INode>& stmt) {
-  auto table_name_node = stmt->Child(0);
-  ValidateHasChildren(table_name_node);
+  for (unsigned i = 0; HasChildren(stmt, i + 1); ++i) {
+    auto table_name_node = stmt->Child(i);
+    ValidateHasChildren(table_name_node);
+    auto table_name = GetName(table_name_node);
 
-  std::string table_name = GetName(table_name_node);
-  Node node(table_name);
-  WriteCypherQuery(DeleteNodeClauseBuilder::Build(node));
-
-  if (HasChildren(stmt, 2)) {
-    std::vector<std::string> other_table_names = GetList(stmt->Child(1), StmtType::kName);
-    for (auto& other_table_name: other_table_names) {
-      Node other_node(other_table_name);
-      WriteCypherQuery(DeleteNodeClauseBuilder::Build(other_node));
-    }
+    Node node(table_name);
+    WriteCypherQuery(DeleteNodeClauseBuilder::Build(node));
   }
 }
 

--- a/src/translator/ddl/ddl_statements.cpp
+++ b/src/translator/ddl/ddl_statements.cpp
@@ -131,19 +131,12 @@ void Translator::TranslateAlterTableActionAdd(const NodePtr<INode>& action_node,
 }
 void Translator::TranslateAlterTableActionDrop(const NodePtr<INode>& action_node,
                                                std::string& table_name) {
-  std::string msg_suffix = " in \'ALTER TABLE DROP\' statement";
-
-  auto drop_list_def = action_node->Child(0);
-
-  ValidateHasChildren(drop_list_def, 1, "Missing arguments" + msg_suffix);
-  auto object = drop_list_def->Child(0);
-  ValidateHasChildren(object);
-  TranslateDropElement(object, table_name);
-
-  if (HasChildren(drop_list_def, 2)) {
-    auto other_objects = drop_list_def->Child(1);
-    ValidateHasChildren(other_objects);
-    TranslateDropElements(other_objects, table_name);
+  auto alter_drop_list = action_node->Child(0);
+  ValidateHasChildren(alter_drop_list, 1, "Missing arguments in \'ALTER TABLE DROP\' statement");
+  for (unsigned i = 0; HasChildren(alter_drop_list, i + 1); ++i) {
+    auto drop_element = alter_drop_list->Child(i);
+    ValidateHasChildren(drop_element);
+    TranslateDropElement(drop_element, table_name);
   }
 }
 
@@ -224,31 +217,23 @@ void Translator::TranslateTableConstraint(const NodePtr<INode>& constraint_defin
   }
 }
 
-void Translator::TranslateDropElements(const NodePtr<INode>& node, std::string& table_name) {
-  ValidateIsCorrectStmtType(node, StmtType::kAlterDropList);
-  for (unsigned i = 0; HasChildren(node, i + 1); ++i) {
-    auto drop_object = node->Child(0);
-    ValidateHasChildren(drop_object);
-    TranslateDropElement(drop_object, table_name);
-  }
-}
 void Translator::TranslateDropElement(const NodePtr<INode>& node, std::string& table_name) {
-  std::string argument = GetName(node->Child(0));
-  std::vector<std::string> other_arguments;
-  if (HasChildren(node, 2)) {
-    other_arguments = GetList(node->Child(1), StmtType::kName);
+  std::vector<std::string> arguments;
+  for (unsigned i = 0; HasChildren(node, i + 1); ++i) {
+    auto argument_node = node->Child(i);
+    ValidateHasChildren(argument_node);
+    auto argument_name = GetName(argument_node);
+    arguments.push_back(argument_name);
   }
 
   switch (node->stmt_type) {
     case StmtType::kDropColumn:
-      RemoveProperty(table_name, argument);
-      for (const auto& arg: other_arguments) {
+      for (const auto& arg: arguments) {
         RemoveProperty(table_name, arg);
       }
       break;
     case StmtType::kDropConstraint:
-      WriteCypherQuery(DropConstraintClauseBuilder::Build(argument));
-      for (const auto& arg: other_arguments) {
+      for (const auto& arg: arguments) {
         WriteCypherQuery(DropConstraintClauseBuilder::Build(arg));
       }
       break;

--- a/src/translator/ddl/ddl_statements.cpp
+++ b/src/translator/ddl/ddl_statements.cpp
@@ -290,20 +290,17 @@ std::shared_ptr<INode> Translator::FindConstraint(const NodePtr<INode>& node) {
 
 void Translator::TranslateDropElements(const NodePtr<INode>& node, std::string& table_name) {
   ValidateIsCorrectStmtType(node, StmtType::kDropList);
-  auto drop_object = node->Child(0);
-  ValidateHasChildren(drop_object);
-  TranslateDropElement(drop_object, table_name);
-
-  if (HasChildren(node, 2)) {
-    auto other_objects = node->Child(1);
-    TranslateDropElements(other_objects, table_name);
+  for (unsigned i = 0; HasChildren(node, i + 1); ++i) {
+    auto drop_object = node->Child(0);
+    ValidateHasChildren(drop_object);
+    TranslateDropElement(drop_object, table_name);
   }
 }
 void Translator::TranslateDropElement(const NodePtr<INode>& node, std::string& table_name) {
-  std::string argument = GetIdentifier(node->Child(0));
+  std::string argument = GetName(node->Child(0));
   std::vector<std::string> other_arguments;
   if (HasChildren(node, 2)) {
-    other_arguments = GetList(node->Child(1), StmtType::kIdentifier);
+    other_arguments = GetList(node->Child(1), StmtType::kName);
   }
 
   switch (node->stmt_type) {

--- a/src/translator/translator.cpp
+++ b/src/translator/translator.cpp
@@ -19,7 +19,11 @@ void Translator::Translate() {
   }
 
   ValidateIsCorrectStmtType(ast_, StmtType::kProgram);
-  TranslateProgram(ast_);
+  for (unsigned i = 0; HasChildren(ast_, i + 1); ++i) {
+    auto query = ast_->Child(i);
+    ValidateIsCorrectStmtType(query, StmtType::kQuery);
+    TranslateQuery(query);
+  }
 
   LOGI << "Translation is ended";
 }
@@ -31,19 +35,6 @@ void Translator::FinishCypherQueriesGroup() {
   out_ << std::endl;
 }
 
-void Translator::TranslateProgram(const NodePtr<INode>& program) {
-  auto query = program->Child(0);
-  ValidateIsCorrectStmtType(query, StmtType::kQuery);
-  TranslateQuery(query);
-
-  if (HasChildren(program, 2)) {
-    auto other_queries = program->Child(1);
-    ValidateIsCorrectStmtType(other_queries, StmtType::kSemicolonDelimiter);
-    if (HasChildren(other_queries)) {
-      TranslateProgram(other_queries);
-    }
-  }
-}
 void Translator::TranslateQuery(const NodePtr<INode>& query) {
   if (!HasChildren(query)) {
     LOGD << "Empty query";

--- a/test/ast/stmt_types_test.cpp
+++ b/test/ast/stmt_types_test.cpp
@@ -85,9 +85,9 @@ TEST(StmtTypeOperatorsTests, OutputTest) {
   oss_create_database_stmt << StmtType(StmtType::kCreateDatabaseStmt);
   EXPECT_EQ(kST_CREATE_DATABASE, oss_create_database_stmt.str());
 
-  std::ostringstream oss_drop_list;
-  oss_drop_list << StmtType(StmtType::kDropList);
-  EXPECT_EQ(kST_DROP_LIST, oss_drop_list.str());
+  std::ostringstream oss_alter_drop_list;
+  oss_alter_drop_list << StmtType(StmtType::kAlterDropList);
+  EXPECT_EQ(kST_ALTER_DROP_LIST, oss_alter_drop_list.str());
 
   std::ostringstream oss_condition;
   oss_condition << StmtType(StmtType::kCondition);


### PR DESCRIPTION
Closes #40.

- Removed all delimiters from AST;
- Without delimiters, no need to use recursion during parsing and translation. Now, we are using loops.