### PR TITLE
[#50] Use formatted strings

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,8 +4,8 @@ on:
   push:
   pull_request:
     types:
-    - reopened
-    - ready_for_review
+      - reopened
+      - ready_for_review
     branches:
       - main
       - develop
@@ -13,17 +13,25 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: sudo apt install graphviz
-    - name: Configure
-      run: cmake -S . -B build
-    - name: Build
-      run: cd build && cmake --build .
-    - name: Unit tests
-      run: cd build && ctest
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y cmake graphviz
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt install -y g++-13 gcc-13
+
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: cmake -S . -B build
+
+      - name: Build
+        run: cd build && cmake --build .
+
+      - name: Unit tests
+        run: cd build && ctest

--- a/include/SCC/parser/parser.h
+++ b/include/SCC/parser/parser.h
@@ -2,6 +2,7 @@
 
 #include <deque>
 #include <exception>
+#include <format>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <iostream>
 #include <filesystem>
+#include <format>
 #include <memory>
 #include <tuple>
 #include <string>

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -249,7 +249,7 @@ NodePtr<INode> Parser::ParseString() {
   while (!NodeDataClassifier::IsSingleQuote(peeked_token)) {
     NodePtr<INode> next_word = NextToken();
     if (!string->data.empty()) {
-      string->data + " "; // TODO: Lexer should save whitespace characters.
+      string->data += " "; // TODO: Lexer should save whitespace characters.
     }
     switch (next_word->data_type) {
       case DataType::kInt:

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -6,6 +6,8 @@ using namespace ast;
 using namespace ast::common;
 using namespace parser::common;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -75,47 +77,44 @@ bool Parser::DetermineIsPrefix(const std::string_view& string, const std::string
 NodePtr<INode> Parser::ParsePrimaryKey() {
   NodePtr<INode> primary_key = ASTUtils::CreateServiceNode(StmtType::kPrimaryKey);
 
-  std::string incorrect_msg_prefix = "Incorrect \'PRIMARY KEY\' definition at line ";
+  std::string msg_prefix = "Incorrect \'PRIMARY KEY\' definition at line";
 
   auto next_token = NextToken();
   ValidateIsWord(next_token);
   std::string primary_keyword = ASTUtils::CastToNodeType<StringNode>(next_token)->data;
   if (!DetermineIsPrimaryKey(primary_keyword)) {
-    throw parsing_error(incorrect_msg_prefix + std::to_string(next_token->line)
-                            + ": expected \'PRIMARY\' keyword");
+    throw parsing_error(format("{} {}: expected \'PRIMARY\' keyword",
+                               msg_prefix, next_token->line));
   }
 
-  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                        + ": missing \'KEY\' keyword");
+  ValidateHasTokens(format("{} {}: missing \'KEY\' keyword", msg_prefix, next_token->line));
   next_token = NextToken();
   ValidateIsWord(next_token);
   std::string key_keyword = ASTUtils::CastToNodeType<StringNode>(next_token)->data;
   if (scc::common::LowerCase(key_keyword) != "key") {
-    throw parsing_error(incorrect_msg_prefix + std::to_string(next_token->line)
-                            + ": expected \'KEY\' keyword");
+    throw parsing_error(format("{} {}: expected \'KEY\' keyword", msg_prefix, next_token->line));
   }
 
-  ValidateHasTokens("Missing \'PRIMARY KEY\' definition at line "
-                        + std::to_string(next_token->line));
+  ValidateHasTokens(format("Missing \'PRIMARY KEY\' definition at line {}", next_token->line));
   int line = PeekToken()->line;
   ValidateIsOpeningRoundBracket(NextToken());
 
-  ValidateHasTokens("Missed column name at line " + std::to_string(line));
+  ValidateHasTokens(format("Missed column name at line {}", line));
   while (HasTokens()) {
     NodePtr<INode> column_name = ParseColumnName();
     ASTUtils::Link(primary_key, column_name);
 
     if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       next_token = NextToken();
-      ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                            + ": missing column name after comma");
+      ValidateHasTokens(format("{} {}: missing column name after comma",
+                               msg_prefix, next_token->line));
       ValidateIsWord(PeekToken());
     } else {
       break;
     }
   }
 
-  ValidateHasTokens("Missed closing round bracket at line " + std::to_string(line));
+  ValidateHasTokens(format("Missed closing round bracket at line {}", line));
   ValidateIsClosingRoundBracket(NextToken());
 
   return primary_key;
@@ -123,96 +122,89 @@ NodePtr<INode> Parser::ParsePrimaryKey() {
 NodePtr<INode> Parser::ParseForeignKey() {
   NodePtr<INode> foreign_key = ASTUtils::CreateServiceNode(StmtType::kForeignKey);
 
-  std::string incorrect_msg_prefix = "Incorrect \'FOREIGN KEY\' definition at line ";
+  std::string msg_prefix = "Incorrect \'FOREIGN KEY\' definition at line ";
 
   auto next_token = NextToken();
   ValidateIsWord(next_token);
   std::string foreign_keyword = ASTUtils::CastToNodeType<StringNode>(next_token)->data;
   if (!DetermineIsForeignKey(foreign_keyword)) {
-    throw parsing_error(incorrect_msg_prefix + std::to_string(next_token->line)
-                            + ": expected \'FOREIGN\' keyword");
+    throw parsing_error(format("{} {}: expected \'FOREIGN\' keyword",
+                               msg_prefix, next_token->line));
   }
 
-  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                        + ": missing \'KEY\' keyword");
+  ValidateHasTokens(format("{} {}: missing \'KEY\' keyword", msg_prefix, next_token->line));
   next_token = NextToken();
   ValidateIsWord(next_token);
   std::string key_keyword = ASTUtils::CastToNodeType<StringNode>(next_token)->data;
   if (scc::common::LowerCase(key_keyword) != "key") {
-    throw parsing_error(incorrect_msg_prefix + std::to_string(next_token->line)
-                            + ": expected \'KEY\' keyword");
+    throw parsing_error(format("{} {}: expected \'KEY\' keyword", msg_prefix, next_token->line));
   }
 
-  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                        + ": missing \'FOREIGN KEY\' definition");
+  ValidateHasTokens(format("{} {}: missing \'FOREIGN KEY\' definition",
+                           msg_prefix, next_token->line));
   next_token = NextToken();
   ValidateIsOpeningRoundBracket(next_token);
 
-  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                        + ": missing referencing column name");
+  ValidateHasTokens(format("{} {}: missing referencing column name", msg_prefix, next_token->line));
   while (HasTokens()) {
     NodePtr<INode> referencing_column_name = ParseColumnName();
     ASTUtils::Link(foreign_key, referencing_column_name);
 
     if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       next_token = NextToken();
-      ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                            + ": missing referencing column name after comma");
+      ValidateHasTokens(format("{} {}: missing referencing column name after comma",
+                               msg_prefix, next_token->line));
       ValidateIsWord(PeekToken());
     } else {
       break;
     }
   }
 
-  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                        + ": missing closing parenthesis");
+  ValidateHasTokens(format("{} {}: missing closing parenthesis", msg_prefix, next_token->line));
   next_token = NextToken();
   ValidateIsClosingRoundBracket(next_token);
 
-  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                        + ": missing \'REFERENCES\' keyword");
+  ValidateHasTokens(format("{} {}: missing \'REFERENCES\' keyword", msg_prefix, next_token->line));
   NodePtr<INode> reference = ParseReference();
   ASTUtils::Link(foreign_key, reference);
 
   return foreign_key;
 }
 NodePtr<INode> Parser::ParseReference() {
-  std::string incorrect_msg_prefix = "Incorrect \'REFERENCES\' definition at line ";
+  std::string msg_prefix = "Incorrect \'REFERENCES\' definition at line ";
 
   auto next_token = NextToken();
   ValidateIsWord(next_token);
   std::string references_keyword = ASTUtils::CastToNodeType<StringNode>(next_token)->data;
   if (!DetermineIsReferences(references_keyword)) {
-    throw parsing_error(incorrect_msg_prefix + std::to_string(next_token->line));
+    throw parsing_error(format("{} {}", msg_prefix, next_token->line));
   }
   NodePtr<INode> reference = ASTUtils::CreateServiceNode(StmtType::kReferencesKW, next_token);
 
-  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                        + ": missing references table name");
+  ValidateHasTokens(format("{} {}: missing references table name", msg_prefix, next_token->line));
   NodePtr<INode> referenced_table_name = ParseTableName();
   ASTUtils::Link(reference, referenced_table_name);
 
   if (HasTokens() && NodeDataClassifier::IsOpeningRoundBracket(PeekToken())) {
     next_token = NextToken();
 
-    ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                          + ": missing referenced column name");
+    ValidateHasTokens(format("{} {}: missing referenced column name",
+                             msg_prefix, next_token->line));
     while (HasTokens()) {
       NodePtr<INode> referenced_column_name = ParseColumnName();
       ASTUtils::Link(reference, referenced_column_name);
 
       if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
         next_token = NextToken();
-        ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                              + ": missing referenced column name after comma");
+        ValidateHasTokens(format("{} {}: missing referenced column name after comma",
+                                 msg_prefix, next_token->line));
         ValidateIsWord(PeekToken());
       } else {
         break;
       }
     }
 
-    ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                          + ": missing closing parenthesis");
+    ValidateHasTokens(format("{} {}: missing closing parenthesis", msg_prefix, next_token->line));
     ValidateIsClosingRoundBracket(NextToken());
   }
 
@@ -240,8 +232,7 @@ NodePtr<INode> Parser::ParseDataType() {
     StmtType sql_datatype(datatype);
     next_token->stmt_type = sql_datatype;
   } catch (const std::invalid_argument& ia) {
-    throw parsing_error("Unknown Data Type \'" + datatype
-                            + "\' at line " + std::to_string(next_token->line));
+    throw parsing_error(format("Unknown Data Type \'{}\' at line {}", datatype, next_token->line));
   }
   return next_token;
 }
@@ -249,8 +240,8 @@ NodePtr<INode> Parser::ParseString() {
   auto next_token = NextToken();
   ValidateIsSingleQuote(next_token);
 
-  ValidateHasTokens("Missing string literal content or closing single quote at line "
-                        + std::to_string(next_token->line));
+  ValidateHasTokens(format("Missing string literal content or closing single quote at line {}",
+                           next_token->line));
   NodePtr<StringNode> string = ASTUtils::CastToNodeType<StringNode>(
       ASTUtils::CreateStringNode("", DataType::kString)
   );
@@ -276,11 +267,12 @@ NodePtr<INode> Parser::ParseString() {
         string->data += ASTUtils::CastToNodeType<StringNode>(next_word)->data;
         break;
       default:
-        throw parsing_error("Invalid string at line " + std::to_string(next_word->line)
-                                + ": unsupported data type for string literal part");
+        throw parsing_error(format("Invalid string at line {}:"
+                                   "unsupported data type for string literal part",
+                                   next_word->line));
     }
-    ValidateHasTokens("Missing closing single quote or string literal part at line "
-                          + std::to_string(next_word->line));
+    ValidateHasTokens(format("Missing closing single quote or string literal part at line {}",
+                             next_word->line));
   }
   NextToken(); // Pop closing single quote
 
@@ -295,8 +287,8 @@ NodePtr<INode> Parser::ParseName() {
 
     if (HasTokens() && NodeDataClassifier::IsDot(PeekToken())) {
       auto next_token = NextToken();
-      ValidateHasTokens("Missing identifier after the dot delimiter at line "
-                            + std::to_string(next_token->line));
+      ValidateHasTokens(format("Missing identifier after the dot delimiter at line {}",
+                               next_token->line));
       ValidateIsWord(PeekToken());
     } else {
       break;

--- a/src/parser/common/validation.cpp
+++ b/src/parser/common/validation.cpp
@@ -5,6 +5,8 @@ namespace scc::parser {
 using namespace ast;
 using namespace common;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -24,9 +26,9 @@ void Parser::ValidateHasTokens(const std::string& details) const {
 }
 void Parser::ValidateHasTokens(unsigned min_count) const {
   if (!HasTokens(min_count)) {
-    std::string msg = "Unexpected empty tokens array";
-    std::string cause = ": expected at least " + std::to_string(min_count) + " tokens";
-    throw parsing_error(msg + cause);
+    std::string msg = format("Unexpected empty tokens array: expected at least {} tokens",
+                             min_count);
+    throw parsing_error(msg);
   }
 }
 void Parser::ValidateHasNotTokens() const {
@@ -36,32 +38,38 @@ void Parser::ValidateHasNotTokens() const {
 }
 void Parser::ValidateIsWord(const NodePtr<INode>& node) const {
   if (!NodeDataTypeClassifier::IsWord(node)) {
-    throw parsing_error("Expected Word at line " + std::to_string(node->line));
+    std::string msg = format("Expected Word at line {}", node->line);
+    throw parsing_error(msg);
   }
 }
 void Parser::ValidateIsOpeningRoundBracket(const NodePtr<INode>& node) const {
   if (!NodeDataClassifier::IsOpeningRoundBracket(node)) {
-    throw parsing_error("Expected Opening Round Bracket at line " + std::to_string(node->line));
+    std::string msg = format("Expected Opening Round Bracket at line {}", node->line);
+    throw parsing_error(msg);
   }
 }
 void Parser::ValidateIsClosingRoundBracket(const NodePtr<INode>& node) const {
   if (!NodeDataClassifier::IsClosingRoundBracket(node)) {
-    throw parsing_error("Expected Closing Round Bracket at line " + std::to_string(node->line));
+    std::string msg = format("Expected Closing Round Bracket at line {}", node->line);
+    throw parsing_error(msg);
   }
 }
 void Parser::ValidateIsSingleQuote(const NodePtr<INode>& node) const {
   if (!NodeDataClassifier::IsSingleQuote(node)) {
-    throw parsing_error("Expected Single Quote at line " + std::to_string(node->line));
+    std::string msg = format("Expected Single Quote at line {}", node->line);
+    throw parsing_error(msg);
   }
 }
 void Parser::ValidateIsDoubleQuote(const NodePtr<INode>& node) const {
   if (!NodeDataClassifier::IsSingleQuote(node)) {
-    throw parsing_error("Expected Double Quote at line " + std::to_string(node->line));
+    std::string msg = format("Expected Double Quote at line {}", node->line);
+    throw parsing_error(msg);
   }
 }
 void Parser::ValidateIsBinaryOperator(const NodePtr<INode>& node) const {
   if (!NodeDataClassifier::IsBinaryOperator(node)) {
-    throw parsing_error("Expected Binary Operator at line " + std::to_string(node->line));
+    std::string msg = format("Expected Binary Operator at line {}", node->line);
+    throw parsing_error(msg);
   }
 }
 

--- a/src/parser/ddl/ddl_statements.cpp
+++ b/src/parser/ddl/ddl_statements.cpp
@@ -6,6 +6,8 @@ using namespace ast;
 using namespace ast::common;
 using namespace parser::common;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -16,8 +18,8 @@ StmtType Parser::ParseDDLStatementType() {
   auto first_keyword_token = ASTUtils::CastToNodeType<StringNode>(next_token);
   std::string first_keyword = first_keyword_token->data;
 
-  ValidateHasTokens("Missed keyword for \'" + first_keyword + "\' DDL statement at line "
-                        + std::to_string(first_keyword_token->line));
+  ValidateHasTokens(format("Missed keyword for \'{}\' DDL statement at line {}",
+                           first_keyword, first_keyword_token->line));
   next_token = NextToken();
   ValidateIsWord(next_token);
   auto second_keyword_token = ASTUtils::CastToNodeType<StringNode>(next_token);
@@ -28,8 +30,8 @@ StmtType Parser::ParseDDLStatementType() {
     StmtType ddl_stmt_type(ddl_stmt);
     return ddl_stmt_type;
   } catch (const std::invalid_argument& ia) {
-    throw parsing_error("Unsupported DDL Statement \'" + ddl_stmt + "\' at line "
-                            + std::to_string(first_keyword_token->line));
+    throw parsing_error(format("Unsupported DDL Statement \'{}\' at line {}",
+                               ddl_stmt, first_keyword_token->line));
   }
 }
 NodePtr<INode> Parser::ParseDDLStatement() {
@@ -37,8 +39,8 @@ NodePtr<INode> Parser::ParseDDLStatement() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kDdlStmt, peeked_token);
 
   StmtType ddl_stmt_type = ParseDDLStatementType();
-  ValidateHasTokens("Missed body for \'" + scc::common::UpperCase(ddl_stmt_type.ToString())
-                        + "\' statement at line" + std::to_string(peeked_token->line));
+  ValidateHasTokens(format("Missed body for \'{}\' statement at line {}",
+                           scc::common::UpperCase(ddl_stmt_type.ToString()), peeked_token->line));
   NodePtr<INode> statement;
   switch (ddl_stmt_type) {
     case StmtType::kCreateDatabaseStmt:
@@ -57,7 +59,7 @@ NodePtr<INode> Parser::ParseDDLStatement() {
       statement = ParseDropTableStatement();
       break;
     default:
-      throw parsing_error("Unknown DDL Statement at line " + std::to_string(peeked_token->line));
+      throw parsing_error(format("Unknown DDL Statement at line {}", peeked_token->line));
   }
   ASTUtils::Link(service_node, statement);
 
@@ -77,7 +79,7 @@ NodePtr<INode> Parser::ParseCreateTableStatement() {
   NodePtr<INode> table_name = ParseTableName();
   ASTUtils::Link(service_node, table_name);
 
-  ValidateHasTokens("Missed table definition at line " + std::to_string(peeked_token->line));
+  ValidateHasTokens(format("Missed table definition at line {}", peeked_token->line));
   NodePtr<INode> table_definition = ParseTableDefinition();
   ASTUtils::Link(service_node, table_definition);
 
@@ -90,16 +92,15 @@ NodePtr<INode> Parser::ParseAlterTableStatement() {
   NodePtr<INode> table_name = ParseName();
   ASTUtils::Link(service_node, table_name);
 
-  std::string incorrect_msg_prefix = "Incorrect \'ALTER TABLE\' definition at line ";
+  std::string msg_prefix = "Incorrect \'ALTER TABLE\' definition at line";
 
-  ValidateHasTokens(incorrect_msg_prefix + std::to_string(line)
-                        + ": expected \'ADD\' or \'DROP\' keyword");
+  ValidateHasTokens(format(R"({} {}: expected 'ADD' or 'DROP' keyword)", msg_prefix, line));
   auto next_token = NextToken();
   ValidateIsWord(next_token);
   std::string action_keyword = ASTUtils::CastToNodeType<StringNode>(next_token)->data;
 
-  ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line) + ": expected \'"
-                        + action_keyword + "\' definition");
+  ValidateHasTokens(format("{} {}: expected \'{}\' definition",
+                           msg_prefix , next_token->line, action_keyword));
   NodePtr<INode> argument;
   StmtType action_type = DetermineAlterTableActionType(action_keyword);
   switch (action_type) {
@@ -111,8 +112,8 @@ NodePtr<INode> Parser::ParseAlterTableStatement() {
       break;
     default:
       line = PeekToken()->line;
-      throw parsing_error(incorrect_msg_prefix + std::to_string(line) + ": unknown action \'"
-                              + action_keyword + "\'");
+      throw parsing_error(format("{} {}: unknown action \'{}\'",
+                                 msg_prefix, line, action_keyword));
   }
   NodePtr<INode> action = ASTUtils::CreateServiceNode(action_type);
   ASTUtils::Link(action, argument);
@@ -129,9 +130,8 @@ NodePtr<INode> Parser::ParseDropDatabaseStatement() {
 
     if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
-      ValidateHasTokens("Invalid \'DROP DATABASE\' statement at line "
-                            + std::to_string(next_token->line)
-                            + ": expected database name after comma");
+      ValidateHasTokens(format("Invalid \'DROP DATABASE\' statement at line {}"
+                               ": expected database name after comma", next_token->line));
       ValidateIsWord(PeekToken());
     } else {
       break;
@@ -149,9 +149,8 @@ NodePtr<INode> Parser::ParseDropTableStatement() {
 
     if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
-      ValidateHasTokens("Invalid \'DROP TABLE\' statement at line "
-                            + std::to_string(next_token->line)
-                            + ": expected table name after comma");
+      ValidateHasTokens(format("Invalid \'DROP TABLE\' statement at line {}"
+                               ": expected table name after comma", next_token->line));
       ValidateIsWord(PeekToken());
     } else {
       break;
@@ -162,7 +161,8 @@ NodePtr<INode> Parser::ParseDropTableStatement() {
 }
 
 NodePtr<INode> Parser::ParseTableDefinition() {
-  ValidateIsOpeningRoundBracket(NextToken());
+  auto next_token = NextToken();
+  ValidateIsOpeningRoundBracket(next_token);
 
   NodePtr<INode> table_definition = ASTUtils::CreateServiceNode(StmtType::kTableDef);
 
@@ -171,16 +171,16 @@ NodePtr<INode> Parser::ParseTableDefinition() {
     ASTUtils::Link(table_definition, table_definition_element);
 
     if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
-      auto next_token = NextToken();
-      ValidateHasTokens("Invalid table definition at line " + std::to_string(next_token->line)
-                            + ": expected column or constraint definition");
+      next_token = NextToken();
+      ValidateHasTokens(format("Invalid table definition at line {}"
+                               ": expected column or constraint definition", next_token->line));
       ValidateIsWord(PeekToken());
     } else {
       break;
     }
   }
 
-  ValidateHasTokens("Missing closing round bracket at line "); // TODO: add line number
+  ValidateHasTokens(format("Missing closing round bracket at line {}", next_token->line));
   ValidateIsClosingRoundBracket(NextToken());
 
   return table_definition;
@@ -196,8 +196,8 @@ NodePtr<INode> Parser::ParseTableDefinitionElement() {
     case StmtType::kForeignKey:
       return ParseTableConstraint(stmt_type);
     default:
-      throw parsing_error("Unknown element in table definition at line "
-                              + std::to_string(peeked_token->line));
+      throw parsing_error(format("Unknown element in table definition at line {}",
+                                 peeked_token->line));
   }
 }
 StmtType Parser::ParseTableDefinitionElementType() {
@@ -220,13 +220,9 @@ NodePtr<INode> Parser::ParseColumnDefinition() {
   NodePtr<INode> column_name = ParseColumnName();
   ASTUtils::Link(service_node, column_name);
 
-  ValidateHasTokens("Missing column datatype at line " + std::to_string(line));
+  ValidateHasTokens(format("Missing column datatype at line {}" , line));
   NodePtr<INode> datatype = ParseDataType();
   ASTUtils::Link(service_node, datatype);
-
-  if (HasTokens()) {
-    // TODO: parse options such as IDENTITY or (NOT) NULL.
-  }
 
   return service_node;
 }
@@ -239,15 +235,14 @@ NodePtr<INode> Parser::ParseTableConstraint(StmtType stmt_type) {
         ASTUtils::CreateServiceNode(StmtType::kConstraintKW, NextToken());
     ASTUtils::Link(service_node, constraint_keyword);
 
-    ValidateHasTokens("Missing constraint name at line "
-                          + std::to_string(constraint_keyword->line));
+    ValidateHasTokens(format("Missing constraint name at line {}", constraint_keyword->line));
     ValidateIsWord(PeekToken());
     NodePtr<INode> constraint_name = ParseConstraintName();
     line = constraint_name->line;
     ASTUtils::Link(constraint_keyword, constraint_name);
   }
 
-  ValidateHasTokens("Missing constraint definition at line " + std::to_string(line));
+  ValidateHasTokens(format("Missing constraint definition at line {}" , line));
   auto peeked_token = PeekToken();
   StmtType constraint_type;
   if (stmt_type != StmtType::kNone && stmt_type != StmtType::kConstraintKW) {
@@ -267,7 +262,7 @@ NodePtr<INode> Parser::ParseTableConstraint(StmtType stmt_type) {
       constraint_definition = ParseForeignKey();
       break;
     default:
-      throw parsing_error("Unknown constraint type at line " + std::to_string(peeked_token->line));
+      throw parsing_error(format("Unknown constraint type at line {}" , peeked_token->line));
   }
   ASTUtils::Link(service_node, constraint_definition);
 
@@ -283,8 +278,8 @@ NodePtr<INode> Parser::ParseAlterAddListDefinition() {
 
     if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
-      ValidateHasTokens("Missing \'ALTER TABLE ... ADD\' element in list at line "
-                            + std::to_string(next_token->line));
+      ValidateHasTokens(format("Missing \'ALTER TABLE ... ADD\' element in list at line {}",
+                               next_token->line));
       ValidateIsWord(PeekToken());
     } else {
       break;
@@ -305,8 +300,8 @@ NodePtr<INode> Parser::ParseAlterDropListDefinition() {
 
     if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
       auto next_token = NextToken();
-      ValidateHasTokens("Missing \'ALTER TABLE ... DROP\' element in list at line "
-                            + std::to_string(next_token->line));
+      ValidateHasTokens(format("Missing \'ALTER TABLE ... DROP\' element in list at line {}",
+                               next_token->line));
       ValidateIsWord(PeekToken());
     } else {
       break;
@@ -321,8 +316,8 @@ NodePtr<INode> Parser::ParseAlterDropElement() {
   StmtType drop_element_type = DetermineDropElementType(keyword);
   NodePtr<INode> drop_element = ASTUtils::CreateServiceNode(drop_element_type);
 
-  ValidateHasTokens("Missing \'ALTER TABLE ... DROP\' element definition at line "
-                        + std::to_string(next_token->line));
+  ValidateHasTokens(format("Missing \'ALTER TABLE ... DROP\' element definition at line {}",
+                           next_token->line));
   auto peeked_token = PeekToken();
   ValidateIsWord(peeked_token);
   switch (drop_element_type) {
@@ -333,8 +328,8 @@ NodePtr<INode> Parser::ParseAlterDropElement() {
       ParseAlterDropConstraints(drop_element);
       break;
     default:
-      throw parsing_error("Unknown \'ALTER TABLE ... DROP\' element type at line "
-                              + std::to_string(peeked_token->line));
+      throw parsing_error(format("Unknown \'ALTER TABLE ... DROP\' element type at line {}",
+                                 peeked_token->line));
   }
 
   return drop_element;
@@ -360,8 +355,7 @@ void Parser::ParseAlterDropColumns(NodePtr<INode>& parent) {
     }
 
     auto next_token = NextToken();
-    ValidateHasTokens("Missing column name after comma at line "
-                          + std::to_string(next_token->line));
+    ValidateHasTokens(format("Missing column name after comma at line {}", next_token->line));
     ValidateIsWord(PeekToken());
   }
 }
@@ -386,8 +380,7 @@ void Parser::ParseAlterDropConstraints(NodePtr<INode>& parent) {
     }
 
     auto next_token = NextToken();
-    ValidateHasTokens("Missing column name after comma at line "
-                          + std::to_string(next_token->line));
+    ValidateHasTokens(format("Missing column name after comma at line {}", next_token->line));
     ValidateIsWord(PeekToken());
   }
 }

--- a/src/parser/dml/conditions.cpp
+++ b/src/parser/dml/conditions.cpp
@@ -6,6 +6,8 @@ using namespace ast;
 using namespace ast::common;
 using namespace parser::common;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -26,8 +28,9 @@ NodePtr<INode> Parser::ParseORCondition() {
     std::string checking_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
     if (DetermineIsOROperator(checking_word)) {
       NextToken();
-      ValidateHasTokens("Incorrect \'OR\' condition: expected \'AND\' condition"
-                        "as second operand at line " + std::to_string(peeked_token->line));
+      ValidateHasTokens(format("Incorrect \'OR\' condition:"
+                               "expected \'AND\' condition as second operand at line {}",
+                               peeked_token->line));
       NodePtr<INode> next_and_conditions = ParseANDCondition();
       ASTUtils::Link(service_node, next_and_conditions);
     }
@@ -45,8 +48,9 @@ NodePtr<INode> Parser::ParseANDCondition() {
     std::string checking_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
     if (DetermineIsANDOperator(checking_word)) {
       NextToken();
-      ValidateHasTokens("Incorrect \'AND\' condition: expected \'NOT\' condition"
-                        "as second operand at line " + std::to_string(peeked_token->line));
+      ValidateHasTokens(format("Incorrect \'AND\' condition:"
+                               "expected \'NOT\' condition as second operand at line {}",
+                               peeked_token->line));
       NodePtr<INode> next_not_conditions = ParseNOTCondition();
       ASTUtils::Link(service_node, next_not_conditions);
     }
@@ -66,8 +70,8 @@ NodePtr<INode> Parser::ParseNOTCondition() {
     }
   }
 
-  ValidateHasTokens("Incorrect \'NOT\' condition: expected predicate at line "
-                        + std::to_string(peeked_token->line));
+  ValidateHasTokens(format("Incorrect \'NOT\' condition:"
+                           "expected predicate at line {}", peeked_token->line));
   NodePtr<INode> predicate = ParsePredicate();
   ASTUtils::Link(service_node, predicate);
 
@@ -79,14 +83,14 @@ NodePtr<INode> Parser::ParsePredicate() {
   ASTUtils::Link(service_node, first_operand);
 
   auto peeked_token = PeekToken();
-  ValidateHasTokens("Incorrect predicate at line " + std::to_string(peeked_token->line)
-                        + ": expected binary operator");
+  ValidateHasTokens(format("Incorrect predicate at line {}: expected binary operator",
+                           peeked_token->line));
   ValidateIsBinaryOperator(peeked_token);
   NodePtr<INode> binary_operator = NextToken();
   ASTUtils::Link(service_node, binary_operator);
 
-  ValidateHasTokens("Incorrect predicate at line " + std::to_string(peeked_token->line)
-                        + ": expected second operand for binary operator");
+  ValidateHasTokens(format("Incorrect predicate at line {}:"
+                           "expected second operand for binary operator", peeked_token->line));
   NodePtr<INode> second_operand = ParseExpression();
   ASTUtils::Link(service_node, second_operand);
 
@@ -110,8 +114,8 @@ NodePtr<INode> Parser::ParseExpression() {
     NodePtr<INode> unary_operator = NextToken();
     ASTUtils::Link(service_node, unary_operator);
 
-    ValidateHasTokens("Incorrect unary operator at line " + std::to_string(peeked_token->line)
-                          + ": expected operand");
+    ValidateHasTokens(format("Incorrect unary operator at line {}: expected operand",
+                             peeked_token->line));
     NodePtr<INode> expression = ParseExpression();
     ASTUtils::Link(service_node, expression);
 
@@ -122,12 +126,12 @@ NodePtr<INode> Parser::ParseExpression() {
   if (NodeDataClassifier::IsOpeningRoundBracket(peeked_token)) {
     NextToken();
 
-    ValidateHasTokens("Incorrect expression at line " + std::to_string(peeked_token->line)
-                          + ": incorrect parenthesis sequence \'(\'");
+    ValidateHasTokens(format("Incorrect expression at line {}:"
+                             "incorrect parenthesis sequence \'(\'", peeked_token->line));
     service_node = ParseExpression();
 
-    ValidateHasTokens("Incorrect expression at line " + std::to_string(peeked_token->line)
-                          + ": missing closing parenthesis");
+    ValidateHasTokens(format("Incorrect expression at line {}: missing closing parenthesis",
+                             peeked_token->line));
     ValidateIsClosingRoundBracket(NextToken());
 
     return service_node;
@@ -137,8 +141,8 @@ NodePtr<INode> Parser::ParseExpression() {
   if (NodeDataClassifier::IsQuote(PeekToken())) {
     NextToken();
 
-    ValidateHasTokens("Incorrect expression at line " + std::to_string(peeked_token->line)
-                          + ": expected string literal or closing quote");
+    ValidateHasTokens(format("Incorrect expression at line {}:"
+                             "expected string literal or closing quote", peeked_token->line));
     NodePtr<INode> string = ParseString();
     ASTUtils::Link(service_node, string);
 

--- a/src/parser/dml/dml_statements.cpp
+++ b/src/parser/dml/dml_statements.cpp
@@ -6,6 +6,8 @@ using namespace ast;
 using namespace ast::common;
 using namespace parser::common;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -20,8 +22,8 @@ StmtType Parser::ParseDMLStatementType() {
     StmtType ddl_stmt_type(keyword);
     return ddl_stmt_type;
   } catch (const std::invalid_argument& ia) {
-    throw parsing_error("Unsupported DML Statement \'" + keyword + "\' at line "
-                            + std::to_string(keyword_token->line));
+    throw parsing_error(format("Unsupported DML Statement \'{}\' at line {}",
+                               keyword, keyword_token->line));
   }
 }
 NodePtr<INode> Parser::ParseDMLStatement() {
@@ -29,8 +31,8 @@ NodePtr<INode> Parser::ParseDMLStatement() {
   NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kDmlStmt, peeked_token);
 
   StmtType dml_stmt_type = ParseDMLStatementType();
-  ValidateHasTokens("Missed body for \'" + scc::common::UpperCase(dml_stmt_type.ToString())
-                        + "\' statement at line" + std::to_string(peeked_token->line));
+  ValidateHasTokens(format("Missed body for \'{}\' statement at line {}",
+                           scc::common::UpperCase(dml_stmt_type.ToString()), peeked_token->line));
   NodePtr<INode> statement;
   switch (dml_stmt_type) {
     case StmtType::kUpdateStmt:
@@ -43,7 +45,7 @@ NodePtr<INode> Parser::ParseDMLStatement() {
       statement = ParseInsertStatement();
       break;
     default:
-      throw parsing_error("Unknown DML Statement at line " + std::to_string(peeked_token->line));
+      throw parsing_error(format("Unknown DML Statement at line {}", peeked_token->line));
   }
   ASTUtils::Link(service_node, statement);
 

--- a/src/parser/dml/math_expressions.cpp
+++ b/src/parser/dml/math_expressions.cpp
@@ -6,6 +6,8 @@ using namespace ast;
 using namespace ast::common;
 using namespace parser::common;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -34,9 +36,9 @@ NodePtr<INode> Parser::ParseMathSum() {
       NextToken();
       ASTUtils::Link(operator_node, lhs_product);
 
-      ValidateHasTokens("Incorrect math expression at line " + std::to_string(operator_node->line)
-                            + ": missing second operand for \'" + operator_str
-                            + "\' binary operator");
+      ValidateHasTokens(format("Incorrect math expression at line {}"
+                               ": missing second operand for \'{}\' binary operator",
+                               operator_node->line, operator_str));
       NodePtr<INode> rhs_product = ParseMathProduct();
       ASTUtils::Link(operator_node, rhs_product);
       return operator_node;
@@ -55,9 +57,9 @@ NodePtr<INode> Parser::ParseMathProduct() {
       NextToken();
       ASTUtils::Link(operator_node, lhs_power);
 
-      ValidateHasTokens("Incorrect math expression at line " + std::to_string(operator_node->line)
-                            + ": missing second operand for \'" + operator_str
-                            + "\' binary operator");
+      ValidateHasTokens(format("Incorrect math expression at line {}"
+                               ": missing second operand for \'\' binary operator",
+                               operator_node->line, operator_str));
       NodePtr<INode> rhs_power = ParseMathPower();
       ASTUtils::Link(operator_node, rhs_power);
       return operator_node;
@@ -76,9 +78,9 @@ NodePtr<INode> Parser::ParseMathPower() {
       NextToken();
       ASTUtils::Link(operator_node, value);
 
-      ValidateHasTokens("Incorrect math expression at line " + std::to_string(operator_node->line)
-                            + ": missing second operand for \'" + operator_str
-                            + "\' binary operator");
+      ValidateHasTokens(format("Incorrect math expression at line {}"
+                               ": missing second operand for \'{}\' binary operator",
+                               operator_node->line, operator_str));
       NodePtr<INode> power = ParseMathPower();
       ASTUtils::Link(operator_node, power);
       return operator_node;
@@ -95,25 +97,25 @@ NodePtr<INode> Parser::ParseMathValue() {
     return number;
   }
 
-  std::string incorrect_msg_prefix = "Incorrect math expression at line ";
+  std::string msg_prefix = "Incorrect math expression at line ";
 
   if (NodeDataClassifier::IsOpeningRoundBracket(peeked_token)) {
     auto next_token = NextToken();
 
-    ValidateHasTokens(incorrect_msg_prefix + std::to_string(next_token->line)
-                          + ": incorrect parenthesis sequence \'(\'");
+    ValidateHasTokens(format("{} {}: incorrect parenthesis sequence \'(\'",
+                             msg_prefix, next_token->line));
     NodePtr<INode> math_expression = ParseMathExpression();
 
-    ValidateHasTokens(incorrect_msg_prefix + std::to_string(math_expression->line)
-                          + ": missing closing parenthesis");
+    ValidateHasTokens(format("{} {}: missing closing parenthesis",
+                             msg_prefix, math_expression->line));
     next_token = NextToken();
     ValidateIsClosingRoundBracket(next_token);
 
     return math_expression;
   }
 
-  throw parsing_error(incorrect_msg_prefix + std::to_string(peeked_token->line)
-                          + ": expected number or math expression in parentheses");
+  throw parsing_error(format("{} {}: expected number or math expression in parentheses",
+                             msg_prefix, peeked_token->line));
 }
 
 } // scc::parser

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -6,6 +6,8 @@ using namespace ast;
 using namespace ast::common;
 using namespace parser::common;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -65,7 +67,7 @@ NodePtr<INode> Parser::ParseBaseStatement() {
   } else if (BaseStmtTypeClassifier::IsDMLKeyword(keyword)) {
     return ParseDMLStatement();
   } else {
-    throw parsing_error("Unknown Base Statement at line " + std::to_string(peeked_token->line));
+    throw parsing_error(format("Unknown Base Statement at line {}", peeked_token->line));
   }
 }
 

--- a/src/translator/common/validation.cpp
+++ b/src/translator/common/validation.cpp
@@ -5,6 +5,8 @@ namespace scc::translator {
 using namespace ast;
 using namespace scc::common;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -30,8 +32,9 @@ void Translator::ValidateHasChildren(const NodePtr<INode>& node, unsigned min_ch
 }
 void Translator::ValidateIsCorrectStmtType(const NodePtr<INode>& node, StmtType stmt_type) const {
   if (!IsCorrectStmtType(node, stmt_type)) {
-    throw translation_error("Unexpected statement type \'" + UpperCase(node->stmt_type.ToString())
-                                + "\': Expected \'" + UpperCase(stmt_type.ToString()) + "\'");
+    throw translation_error(format("Unexpected statement type \'{}\': expected \'{}\'",
+                                   UpperCase(node->stmt_type.ToString()),
+                                   UpperCase(stmt_type.ToString())));
   }
 }
 

--- a/src/translator/ddl/ddl_statements.cpp
+++ b/src/translator/ddl/ddl_statements.cpp
@@ -5,6 +5,8 @@ namespace scc::translator {
 using namespace ast;
 using namespace cypher;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -27,8 +29,8 @@ void Translator::TranslateDDLStatement(const NodePtr<INode>& ddl_statement) {
       TranslateDropTableStatement(ddl_statement);
       break;
     default:
-      throw translation_error("Unknown DDL statement type: \'"
-                                  + ddl_statement->stmt_type.ToString() + "\'");
+      throw translation_error(format("Unknown DDL statement type: \'{}\'",
+                                     ddl_statement->stmt_type.ToString()));
   }
 }
 
@@ -83,8 +85,8 @@ void Translator::TranslateAlterTableStatement(const NodePtr<INode>& stmt) {
       TranslateAlterTableActionDrop(action_node, table_name);
       break;
     default:
-      throw translation_error("Unknown action type \'" + action_node->stmt_type.ToString()
-                                  + "\'" + msg_suffix);
+      throw translation_error(format("Unknown action type \'{}\' {}",
+                                     action_node->stmt_type.ToString(), msg_suffix));
   }
 }
 void Translator::TranslateDropDatabaseStatement(const NodePtr<INode>& stmt) {
@@ -180,7 +182,7 @@ NodeProperty Translator::TranslateColumnDefinition(const NodePtr<INode>& node) {
       property_type = PropertyType::kString;
       break;
     default:
-      throw translation_error("Unknown SQL datatype \'" + datatype.ToString() + "\'");
+      throw translation_error(format("Unknown SQL datatype \'{}\'", datatype.ToString()));
   }
 
   return NodeProperty(column_name, datatype_str, property_type);
@@ -211,7 +213,7 @@ void Translator::TranslateTableConstraint(const NodePtr<INode>& constraint_defin
       TranslateForeignKey(key, constraint_name, table_name);
       break;
     default:
-      throw translation_error("Unknown constraint type \'" + key->stmt_type.ToString() + "\'");
+      throw translation_error(format("Unknown constraint type \'{}\'", key->stmt_type.ToString()));
   }
 }
 
@@ -236,7 +238,8 @@ void Translator::TranslateDropElement(const NodePtr<INode>& node, std::string& t
       }
       break;
     default:
-      throw translation_error("Unknown drop object type \'" + node->stmt_type.ToString() + "\'");
+      throw translation_error(format("Unknown drop object type \'{}\'",
+                                     node->stmt_type.ToString()));
   }
 }
 

--- a/src/translator/dml/dml_statements.cpp
+++ b/src/translator/dml/dml_statements.cpp
@@ -4,6 +4,8 @@ namespace scc::translator {
 
 using namespace ast;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
@@ -20,8 +22,8 @@ void Translator::TranslateDMLStatement(const NodePtr<INode>& dml_statement) {
       TranslateUpdateStatement(dml_statement);
       break;
     default:
-      throw translation_error("Unknown DML statement type: \'"
-                                  + dml_statement->stmt_type.ToString() + "\'");
+      throw translation_error(format("Unknown DML statement type: \'{}\'",
+                                     dml_statement->stmt_type.ToString()));
   }
 }
 

--- a/src/translator/translator.cpp
+++ b/src/translator/translator.cpp
@@ -53,8 +53,8 @@ void Translator::TranslateQuery(const NodePtr<INode>& query) {
       TranslateDMLStatement(statement);
       break;
     default:
-      throw translation_error("Unknown query statement type: \'"
-                                  + statement_type->stmt_type.ToString() + "\'");
+      throw translation_error(format("Unknown query statement type: \'{}\'",
+                                     statement_type->stmt_type.ToString()));
   }
 
   FinishCypherQueriesGroup();


### PR DESCRIPTION
Closes #50.

- Added formatted strings to parser and translator modules using `std::format` method.