### PR TITLE
[#52] Translate DDL queries to Neo4j schema

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,12 @@ FetchContent_Declare(
         GIT_TAG 997da9255618311d1fcb0135ce86022729d1f1cb # release-2.9
 )
 FetchContent_MakeAvailable(argparse)
+FetchContent_Declare(
+        json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG 1d597743d89eec9a1b599bfc69e36db94a5fe05c # release-3.11.3
+)
+FetchContent_MakeAvailable(json)
 
 ## Build sources
 
@@ -72,6 +78,7 @@ target_include_directories(scc_include INTERFACE
         include
         ${logger_SOURCE_DIR}/include
         ${argparse_SOURCE_DIR}/include
+        ${json_SOURCE_DIR}/include
 )
 set(SCC_INCLUDE_LIBS scc_include)
 
@@ -98,6 +105,7 @@ target_link_libraries(${PRJ_TARGET} PUBLIC
 target_link_libraries(${PRJ_TARGET} PUBLIC
         liblogger
         argparse
+        nlohmann_json::nlohmann_json
 )
 
 # Tests

--- a/include/SCC/ast_handler.h
+++ b/include/SCC/ast_handler.h
@@ -1,1 +1,0 @@
-#pragma once

--- a/include/SCC/config/scc_config.h
+++ b/include/SCC/config/scc_config.h
@@ -21,6 +21,7 @@ public:
   logger::Severity log_severity;
   fs::path log_directory;
   SCCMode mode;
+  bool translate_schema;
 
   explicit SCCConfig(const SCCArgs& args);
 

--- a/include/SCC/translator/cypher/clauses/create.h
+++ b/include/SCC/translator/cypher/clauses/create.h
@@ -25,7 +25,7 @@ public:
 class CreateConstraintClauseBuilder {
 public:
   static std::string Build(const std::string& constraint_name, const Node& node,
-                           const NodeProperty& property, ConstraintType type);
+                           const Property& property, ConstraintType type);
 };
 
 class CreateRelationshipClauseBuilder {

--- a/include/SCC/translator/cypher/clauses/create.h
+++ b/include/SCC/translator/cypher/clauses/create.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <format>
+#include <stdexcept>
 #include <string>
 #include <sstream>
 

--- a/include/SCC/translator/cypher/clauses/set.h
+++ b/include/SCC/translator/cypher/clauses/set.h
@@ -10,7 +10,7 @@ namespace scc::translator::cypher {
 
 class SetPropertyClauseBuilder {
 public:
-  static std::string Build(const Node& node, const NodeProperty& property);
+  static std::string Build(const Node& node, const Property& property);
 };
 
 class RemovePropertyClauseBuilder {

--- a/include/SCC/translator/cypher/graph/constraint_types.h
+++ b/include/SCC/translator/cypher/graph/constraint_types.h
@@ -6,6 +6,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "nlohmann/json.hpp"
+
 #include "SCC/common/string_utils.h"
 
 namespace scc::translator::cypher {
@@ -38,9 +40,17 @@ public:
   constexpr bool operator>(const Value& value) const { return value_ > value; }
   constexpr bool operator>=(const Value& value) const { return value_ >= value; }
 
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ConstraintType, value_)
+
 private:
   Value value_ = Value::kNone;
 };
+
+NLOHMANN_JSON_SERIALIZE_ENUM(ConstraintType::Value, {
+  { ConstraintType::Value::kNone, kCT_None },
+  { ConstraintType::Value::kUniqueness, kCT_Uniqueness },
+  { ConstraintType::Value::kExistence, kCT_Existence },
+})
 
 std::ostream& operator<<(std::ostream& os, const ConstraintType& type);
 

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -16,39 +16,26 @@ namespace scc::translator::cypher {
 
 constexpr std::string_view stub_str = "stub";
 
+
 struct Node {
-  struct Label {
-    std::string value;
-
-    explicit Label(std::string value);
-
-    std::string ToString() const;
-  };
-
-  std::set<Label> labels;
+  std::set<std::string> labels;
   std::vector<Property> properties;
   std::string variable;
 
-  explicit Node(std::string label_name);
-  explicit Node(std::string label_name, std::string variable);
-  explicit Node(Label label);
-  explicit Node(Label label, std::vector<Property> properties);
-  explicit Node(Label label, std::vector<Property> properties, std::string variable);
+  explicit Node(std::string label);
+  explicit Node(std::string label, std::string variable);
+  explicit Node(std::string label, std::vector<Property> properties);
+  explicit Node(std::string label, std::vector<Property> properties, std::string variable);
 
   Node& AddProperty(const Property& property);
   Node& AddProperty(const std::string& name, const std::string& value, PropertyType type);
   bool HasProperty(const std::string& name) const;
   unsigned PropertyCount() const;
-  Node& AddLabel(const Label& label);
-  Node& AddLabel(const std::string& label);
   Node& SetVariable(const std::string& variable);
 
   std::string ToString() const;
 };
 
-bool operator==(const Node::Label& lhs, const Node::Label& rhs);
-std::ostream& operator<<(std::ostream& os, const Node::Label& label);
-bool operator<(const Node::Label& lhs, const Node::Label& rhs);
 
 bool operator==(const Node& lhs, const Node& rhs);
 std::ostream& operator<<(std::ostream& os, const Node& node);

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -16,13 +16,9 @@ namespace scc::translator::cypher {
 
 constexpr std::string_view stub_str = "stub";
 
-class BaseNode {
+class Node {
 public:
   std::string label;
-};
-
-class Node : public BaseNode {
-public:
   std::vector<Property> properties;
   std::string variable;
 

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -13,18 +13,15 @@ namespace scc::translator::cypher {
 
 constexpr std::string_view stub_str = "stub";
 
-struct Label {
-  std::string value;
-
-  explicit Label(std::string value);
-
-  std::string ToString() const;
-};
-
-std::ostream& operator<<(std::ostream& os, const Label& label);
-bool operator<(const Label& lhs, const Label& rhs);
-
 struct Node {
+  struct Label {
+    std::string value;
+
+    explicit Label(std::string value);
+
+    std::string ToString() const;
+  };
+
   std::vector<Label> labels = {};
   std::vector<Property> properties = {};
   std::string variable = "";
@@ -45,6 +42,9 @@ struct Node {
 
   std::string ToString() const;
 };
+
+std::ostream& operator<<(std::ostream& os, const Node::Label& label);
+bool operator<(const Node::Label& lhs, const Node::Label& rhs);
 
 std::ostream& operator<<(std::ostream& os, const Node& node);
 

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -40,6 +40,17 @@ public:
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Node, label, properties, variable)
 
+inline void to_json(nlohmann::json& j, const std::vector<Node>& nodes) {
+  j = nlohmann::json::array();
+  for (const auto& node : nodes) {
+    j.push_back(node);
+  }
+}
+
+inline void from_json(const nlohmann::json& j, std::vector<Node>& nodes) {
+  nodes = j.get<std::vector<Node>>();
+}
+
 bool operator==(const Node& lhs, const Node& rhs);
 std::ostream& operator<<(std::ostream& os, const Node& node);
 

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -18,10 +18,14 @@ namespace scc::translator::cypher {
 
 constexpr std::string_view stub_str = "stub";
 
-struct Node {
+class BaseNode {
 public:
   std::string label;
   std::vector<Property> properties;
+};
+
+class Node : public BaseNode {
+public:
   std::string variable;
 
   explicit Node(std::string label);

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <algorithm>
+#include <format>
 #include <ostream>
+#include <stdexcept>
 #include <sstream>
 #include <string>
+#include <set>
 #include <vector>
 #include <utility>
 
@@ -22,9 +25,9 @@ struct Node {
     std::string ToString() const;
   };
 
-  std::vector<Label> labels = {};
-  std::vector<Property> properties = {};
-  std::string variable = "";
+  std::set<Label> labels;
+  std::vector<Property> properties;
+  std::string variable;
 
   explicit Node(std::string label_name);
   explicit Node(std::string label_name, std::string variable);
@@ -43,9 +46,11 @@ struct Node {
   std::string ToString() const;
 };
 
+bool operator==(const Node::Label& lhs, const Node::Label& rhs);
 std::ostream& operator<<(std::ostream& os, const Node::Label& label);
 bool operator<(const Node::Label& lhs, const Node::Label& rhs);
 
+bool operator==(const Node& lhs, const Node& rhs);
 std::ostream& operator<<(std::ostream& os, const Node& node);
 
 } // scc::translator::cypher

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -10,6 +10,8 @@
 #include <vector>
 #include <utility>
 
+#include "nlohmann/json.hpp"
+
 #include "SCC/translator/cypher/graph/property.h"
 
 namespace scc::translator::cypher {
@@ -17,6 +19,7 @@ namespace scc::translator::cypher {
 constexpr std::string_view stub_str = "stub";
 
 struct Node {
+public:
   std::string label;
   std::vector<Property> properties;
   std::string variable;
@@ -35,6 +38,7 @@ struct Node {
   std::string ToString() const;
 };
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Node, label, properties, variable)
 
 bool operator==(const Node& lhs, const Node& rhs);
 std::ostream& operator<<(std::ostream& os, const Node& node);

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -10,8 +10,6 @@
 #include <vector>
 #include <utility>
 
-#include "nlohmann/json.hpp"
-
 #include "SCC/translator/cypher/graph/property.h"
 
 namespace scc::translator::cypher {
@@ -21,11 +19,11 @@ constexpr std::string_view stub_str = "stub";
 class BaseNode {
 public:
   std::string label;
-  std::vector<Property> properties;
 };
 
 class Node : public BaseNode {
 public:
+  std::vector<Property> properties;
   std::string variable;
 
   explicit Node(std::string label);
@@ -41,19 +39,6 @@ public:
 
   std::string ToString() const;
 };
-
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Node, label, properties, variable)
-
-inline void to_json(nlohmann::json& j, const std::vector<Node>& nodes) {
-  j = nlohmann::json::array();
-  for (const auto& node : nodes) {
-    j.push_back(node);
-  }
-}
-
-inline void from_json(const nlohmann::json& j, std::vector<Node>& nodes) {
-  nodes = j.get<std::vector<Node>>();
-}
 
 bool operator==(const Node& lhs, const Node& rhs);
 std::ostream& operator<<(std::ostream& os, const Node& node);

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -16,9 +16,8 @@ namespace scc::translator::cypher {
 
 constexpr std::string_view stub_str = "stub";
 
-
 struct Node {
-  std::set<std::string> labels;
+  std::string label;
   std::vector<Property> properties;
   std::string variable;
 

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -24,31 +24,31 @@ struct Label {
 std::ostream& operator<<(std::ostream& os, const Label& label);
 bool operator<(const Label& lhs, const Label& rhs);
 
-struct NodeProperty {
+struct Property {
   std::string name;
   std::string value;
   PropertyType type;
 
-  explicit NodeProperty(std::string name, std::string value, PropertyType type);
+  explicit Property(std::string name, std::string value, PropertyType type);
 
   std::string ToString() const;
 };
 
-std::ostream& operator<<(std::ostream& os, const NodeProperty& property);
-bool operator<(const NodeProperty& lhs, const NodeProperty& rhs);
+std::ostream& operator<<(std::ostream& os, const Property& property);
+bool operator<(const Property& lhs, const Property& rhs);
 
 struct Node {
   std::vector<Label> labels = {};
-  std::vector<NodeProperty> properties = {};
+  std::vector<Property> properties = {};
   std::string variable = "";
 
   explicit Node(std::string label_name);
   explicit Node(std::string label_name, std::string variable);
   explicit Node(Label label);
-  explicit Node(Label label, std::vector<NodeProperty> properties);
-  explicit Node(Label label, std::vector<NodeProperty> properties, std::string variable);
+  explicit Node(Label label, std::vector<Property> properties);
+  explicit Node(Label label, std::vector<Property> properties, std::string variable);
 
-  Node& AddProperty(const NodeProperty& property);
+  Node& AddProperty(const Property& property);
   Node& AddProperty(const std::string& name, const std::string& value, PropertyType type);
   bool HasProperty(const std::string& name) const;
   unsigned PropertyCount() const;

--- a/include/SCC/translator/cypher/graph/node.h
+++ b/include/SCC/translator/cypher/graph/node.h
@@ -7,7 +7,7 @@
 #include <vector>
 #include <utility>
 
-#include "SCC/translator/cypher/graph/property_types.h"
+#include "SCC/translator/cypher/graph/property.h"
 
 namespace scc::translator::cypher {
 
@@ -23,19 +23,6 @@ struct Label {
 
 std::ostream& operator<<(std::ostream& os, const Label& label);
 bool operator<(const Label& lhs, const Label& rhs);
-
-struct Property {
-  std::string name;
-  std::string value;
-  PropertyType type;
-
-  explicit Property(std::string name, std::string value, PropertyType type);
-
-  std::string ToString() const;
-};
-
-std::ostream& operator<<(std::ostream& os, const Property& property);
-bool operator<(const Property& lhs, const Property& rhs);
 
 struct Node {
   std::vector<Label> labels = {};

--- a/include/SCC/translator/cypher/graph/property.h
+++ b/include/SCC/translator/cypher/graph/property.h
@@ -7,8 +7,6 @@
 #include <vector>
 #include <utility>
 
-#include "nlohmann/json.hpp"
-
 #include "SCC/translator/cypher/graph/constraint_types.h"
 #include "SCC/translator/cypher/graph/property_types.h"
 
@@ -25,32 +23,9 @@ public:
   std::string value;
 
   explicit Property(std::string name, std::string value, PropertyType type);
-  explicit Property(std::string name, std::string value, PropertyType type,
-                    std::vector<ConstraintType> constraints);
-
-  void AddConstraint(ConstraintType constraint);
-  void RemoveConstraint(ConstraintType constraint);
-  bool MustBeUnique() const;
-  bool MustBeNotNull() const;
 
   std::string ToString() const;
-
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(Property, name, value, type, constraints)
-
-private:
-  std::vector<ConstraintType> constraints;
 };
-
-inline void to_json(nlohmann::json& j, const std::vector<Property>& properties) {
-  j = nlohmann::json::array();
-  for (const auto& property : properties) {
-    j.push_back(property);
-  }
-}
-
-inline void from_json(const nlohmann::json& j, std::vector<Property>& properties) {
-  properties = j.get<std::vector<Property>>();
-}
 
 bool operator==(const Property& lhs, const Property& rhs);
 std::ostream& operator<<(std::ostream& os, const Property& property);

--- a/include/SCC/translator/cypher/graph/property.h
+++ b/include/SCC/translator/cypher/graph/property.h
@@ -12,14 +12,10 @@
 
 namespace scc::translator::cypher {
 
-class BaseProperty {
+class Property {
 public:
   std::string name;
   PropertyType type;
-};
-
-class Property : public BaseProperty {
-public:
   std::string value;
 
   explicit Property(std::string name, std::string value, PropertyType type);

--- a/include/SCC/translator/cypher/graph/property.h
+++ b/include/SCC/translator/cypher/graph/property.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <utility>
 
+#include "SCC/translator/cypher/graph/constraint_types.h"
 #include "SCC/translator/cypher/graph/property_types.h"
 
 namespace scc::translator::cypher {
@@ -17,8 +18,18 @@ struct Property {
   PropertyType type;
 
   explicit Property(std::string name, std::string value, PropertyType type);
+  explicit Property(std::string name, std::string value, PropertyType type,
+                    std::vector<ConstraintType> constraints);
+
+  void AddConstraint(ConstraintType constraint);
+  void RemoveConstraint(ConstraintType constraint);
+  bool MustBeUnique() const;
+  bool MustBeNotNull() const;
 
   std::string ToString() const;
+
+private:
+  std::vector<ConstraintType> constraints;
 };
 
 std::ostream& operator<<(std::ostream& os, const Property& property);

--- a/include/SCC/translator/cypher/graph/property.h
+++ b/include/SCC/translator/cypher/graph/property.h
@@ -32,6 +32,7 @@ private:
   std::vector<ConstraintType> constraints;
 };
 
+bool operator==(const Property& lhs, const Property& rhs);
 std::ostream& operator<<(std::ostream& os, const Property& property);
 bool operator<(const Property& lhs, const Property& rhs);
 

--- a/include/SCC/translator/cypher/graph/property.h
+++ b/include/SCC/translator/cypher/graph/property.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <algorithm>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "SCC/translator/cypher/graph/property_types.h"
+
+namespace scc::translator::cypher {
+
+struct Property {
+  std::string name;
+  std::string value;
+  PropertyType type;
+
+  explicit Property(std::string name, std::string value, PropertyType type);
+
+  std::string ToString() const;
+};
+
+std::ostream& operator<<(std::ostream& os, const Property& property);
+bool operator<(const Property& lhs, const Property& rhs);
+
+} // scc::translator::cypher

--- a/include/SCC/translator/cypher/graph/property.h
+++ b/include/SCC/translator/cypher/graph/property.h
@@ -14,10 +14,15 @@
 
 namespace scc::translator::cypher {
 
-struct Property {
+class BaseProperty {
+public:
   std::string name;
-  std::string value;
   PropertyType type;
+};
+
+class Property : public BaseProperty {
+public:
+  std::string value;
 
   explicit Property(std::string name, std::string value, PropertyType type);
   explicit Property(std::string name, std::string value, PropertyType type,

--- a/include/SCC/translator/cypher/graph/property.h
+++ b/include/SCC/translator/cypher/graph/property.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include <utility>
 
+#include "nlohmann/json.hpp"
+
 #include "SCC/translator/cypher/graph/constraint_types.h"
 #include "SCC/translator/cypher/graph/property_types.h"
 
@@ -28,9 +30,22 @@ struct Property {
 
   std::string ToString() const;
 
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(Property, name, value, type, constraints)
+
 private:
   std::vector<ConstraintType> constraints;
 };
+
+inline void to_json(nlohmann::json& j, const std::vector<Property>& properties) {
+  j = nlohmann::json::array();
+  for (const auto& property : properties) {
+    j.push_back(property);
+  }
+}
+
+inline void from_json(const nlohmann::json& j, std::vector<Property>& properties) {
+  properties = j.get<std::vector<Property>>();
+}
 
 bool operator==(const Property& lhs, const Property& rhs);
 std::ostream& operator<<(std::ostream& os, const Property& property);

--- a/include/SCC/translator/cypher/graph/property_types.h
+++ b/include/SCC/translator/cypher/graph/property_types.h
@@ -6,6 +6,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "nlohmann/json.hpp"
+
 #include "SCC/common/string_utils.h"
 
 namespace scc::translator::cypher {
@@ -42,9 +44,19 @@ public:
   constexpr bool operator>(const Value& value) const { return value_ > value; }
   constexpr bool operator>=(const Value& value) const { return value_ >= value; }
 
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(PropertyType, value_)
+
 private:
   Value value_ = Value::kUnknown;
 };
+
+NLOHMANN_JSON_SERIALIZE_ENUM(PropertyType::Value, {
+  { PropertyType::Value::kUnknown, kPT_Unknown },
+  { PropertyType::Value::kBoolean, kPT_Boolean },
+  { PropertyType::Value::kFloat, kPT_Float },
+  { PropertyType::Value::kInteger, kPT_Integer },
+  { PropertyType::Value::kString, kPT_String },
+})
 
 std::ostream& operator<<(std::ostream& os, const PropertyType& type);
 

--- a/include/SCC/translator/cypher/graph/relationship.h
+++ b/include/SCC/translator/cypher/graph/relationship.h
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "SCC/translator/cypher/graph/node.h"
+#include "SCC/translator/cypher/graph/property.h"
 
 namespace scc::translator::cypher {
 
@@ -22,7 +23,7 @@ struct Relationship {
   Node end;
   Direction direction;
   std::string variable;
-//  std::set<NodeProperty> properties;
+  std::vector<Property> properties;
 
   explicit Relationship(std::string type, Node start, Node end,
                         Direction direction = Direction::kRight);

--- a/include/SCC/translator/cypher/graph/relationship.h
+++ b/include/SCC/translator/cypher/graph/relationship.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <utility>
 
+#include "nlohmann/json.hpp"
+
 #include "SCC/translator/cypher/graph/node.h"
 #include "SCC/translator/cypher/graph/property.h"
 
@@ -16,6 +18,12 @@ enum class Direction {
   kRight,
   kBoth,
 };
+
+NLOHMANN_JSON_SERIALIZE_ENUM(Direction, {
+  { Direction::kLeft, "<" },
+  { Direction::kRight, ">" },
+  { Direction::kBoth, "-" },
+})
 
 struct Relationship {
   std::string type;
@@ -37,6 +45,8 @@ private:
   std::string GetRightArrow() const;
 };
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Relationship, type, start, end, direction, properties, variable)
+
 bool operator==(const Relationship& lhs, const Relationship& rhs);
 std::ostream& operator<<(std::ostream& os, const Relationship& rel);
 
@@ -46,7 +56,12 @@ public:
   int epi;
 };
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ApplyCondition, spi, epi)
+
 struct ConditionalRelationship : public Relationship {
+public:
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ConditionalRelationship, conditions)
+
 private:
   std::vector<ApplyCondition> conditions;
 };

--- a/include/SCC/translator/cypher/graph/relationship.h
+++ b/include/SCC/translator/cypher/graph/relationship.h
@@ -25,12 +25,17 @@ NLOHMANN_JSON_SERIALIZE_ENUM(Direction, {
   { Direction::kBoth, "-" },
 })
 
-struct Relationship {
+class BaseRelationship {
+public:
   std::string type;
   Node start;
   Node end;
-  Direction direction;
   std::vector<Property> properties;
+};
+
+class Relationship : public BaseRelationship {
+public:
+  Direction direction;
   std::string variable;
 
   explicit Relationship(std::string type, Node start, Node end,
@@ -53,14 +58,13 @@ bool operator==(const Relationship& lhs, const Relationship& rhs);
 std::ostream& operator<<(std::ostream& os, const Relationship& rel);
 
 struct ApplyCondition {
-public:
   int spi;
   int epi;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ApplyCondition, spi, epi)
 
-struct ConditionalRelationship : public Relationship {
+class ConditionalRelationship : public Relationship {
 public:
   explicit ConditionalRelationship(const Relationship& relationship,
                                    std::vector<ApplyCondition> conditions);

--- a/include/SCC/translator/cypher/graph/relationship.h
+++ b/include/SCC/translator/cypher/graph/relationship.h
@@ -37,6 +37,7 @@ private:
   std::string GetRightArrow() const;
 };
 
+bool operator==(const Relationship& lhs, const Relationship& rhs);
 std::ostream& operator<<(std::ostream& os, const Relationship& rel);
 
 } // scc::translation::cypher

--- a/include/SCC/translator/cypher/graph/relationship.h
+++ b/include/SCC/translator/cypher/graph/relationship.h
@@ -11,19 +11,19 @@
 
 namespace scc::translator::cypher {
 
-struct Relationship {
-  enum class Direction {
-    kLeft,
-    kRight,
-    kBoth,
-  };
+enum class Direction {
+  kLeft,
+  kRight,
+  kBoth,
+};
 
+struct Relationship {
   std::string type;
   Node start;
   Node end;
   Direction direction;
-  std::string variable;
   std::vector<Property> properties;
+  std::string variable;
 
   explicit Relationship(std::string type, Node start, Node end,
                         Direction direction = Direction::kRight);

--- a/include/SCC/translator/cypher/graph/relationship.h
+++ b/include/SCC/translator/cypher/graph/relationship.h
@@ -6,8 +6,6 @@
 #include <string>
 #include <utility>
 
-#include "nlohmann/json.hpp"
-
 #include "SCC/translator/cypher/graph/node.h"
 #include "SCC/translator/cypher/graph/property.h"
 
@@ -19,23 +17,17 @@ enum class Direction {
   kBoth,
 };
 
-NLOHMANN_JSON_SERIALIZE_ENUM(Direction, {
-  { Direction::kLeft, "<" },
-  { Direction::kRight, ">" },
-  { Direction::kBoth, "-" },
-})
-
 class BaseRelationship {
 public:
   std::string type;
-  Node start;
-  Node end;
-  std::vector<Property> properties;
 };
 
 class Relationship : public BaseRelationship {
 public:
+  Node start;
+  Node end;
   Direction direction;
+  std::vector<Property> properties;
   std::string variable;
 
   explicit Relationship(std::string type, Node start, Node end,
@@ -52,41 +44,7 @@ private:
   std::string GetRightArrow() const;
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Relationship, type, start, end, direction, properties, variable)
-
 bool operator==(const Relationship& lhs, const Relationship& rhs);
 std::ostream& operator<<(std::ostream& os, const Relationship& rel);
-
-struct ApplyCondition {
-  int spi;
-  int epi;
-};
-
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ApplyCondition, spi, epi)
-
-class ConditionalRelationship : public Relationship {
-public:
-  explicit ConditionalRelationship(const Relationship& relationship,
-                                   std::vector<ApplyCondition> conditions);
-
-  ConditionalRelationship& AddCondition(ApplyCondition condition);
-
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ConditionalRelationship, type, start, end, direction, properties,
-                                 variable, conditions)
-
-private:
-  std::vector<ApplyCondition> conditions;
-};
-
-inline void to_json(nlohmann::json& j, const std::vector<ConditionalRelationship>& relationships) {
-  j = nlohmann::json::array();
-  for (const auto& relationship : relationships) {
-    j.push_back(relationship);
-  }
-}
-
-inline void from_json(const nlohmann::json& j, std::vector<ConditionalRelationship>& relationships) {
-  relationships = j.get<std::vector<ConditionalRelationship>>();
-}
 
 } // scc::translation::cypher

--- a/include/SCC/translator/cypher/graph/relationship.h
+++ b/include/SCC/translator/cypher/graph/relationship.h
@@ -40,4 +40,15 @@ private:
 bool operator==(const Relationship& lhs, const Relationship& rhs);
 std::ostream& operator<<(std::ostream& os, const Relationship& rel);
 
+struct ApplyCondition {
+public:
+  int spi;
+  int epi;
+};
+
+struct ConditionalRelationship : public Relationship {
+private:
+  std::vector<ApplyCondition> conditions;
+};
+
 } // scc::translation::cypher

--- a/include/SCC/translator/cypher/graph/relationship.h
+++ b/include/SCC/translator/cypher/graph/relationship.h
@@ -17,13 +17,9 @@ enum class Direction {
   kBoth,
 };
 
-class BaseRelationship {
+class Relationship {
 public:
   std::string type;
-};
-
-class Relationship : public BaseRelationship {
-public:
   Node start;
   Node end;
   Direction direction;

--- a/include/SCC/translator/cypher/graph/relationship.h
+++ b/include/SCC/translator/cypher/graph/relationship.h
@@ -37,6 +37,8 @@ struct Relationship {
                         Direction direction = Direction::kRight);
   explicit Relationship(std::string type, Node start, Node end, std::string variable,
                         Direction direction = Direction::kRight);
+  explicit Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
+                        std::string variable, Direction direction = Direction::kRight);
 
   std::string ToString() const;
 
@@ -60,10 +62,27 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ApplyCondition, spi, epi)
 
 struct ConditionalRelationship : public Relationship {
 public:
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ConditionalRelationship, conditions)
+  explicit ConditionalRelationship(const Relationship& relationship,
+                                   std::vector<ApplyCondition> conditions);
+
+  ConditionalRelationship& AddCondition(ApplyCondition condition);
+
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ConditionalRelationship, type, start, end, direction, properties,
+                                 variable, conditions)
 
 private:
   std::vector<ApplyCondition> conditions;
 };
+
+inline void to_json(nlohmann::json& j, const std::vector<ConditionalRelationship>& relationships) {
+  j = nlohmann::json::array();
+  for (const auto& relationship : relationships) {
+    j.push_back(relationship);
+  }
+}
+
+inline void from_json(const nlohmann::json& j, std::vector<ConditionalRelationship>& relationships) {
+  relationships = j.get<std::vector<ConditionalRelationship>>();
+}
 
 } // scc::translation::cypher

--- a/include/SCC/translator/cypher/schema.h
+++ b/include/SCC/translator/cypher/schema.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <algorithm>
+#include <format>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "SCC/translator/cypher/graph/node.h"
+#include "SCC/translator/cypher/graph/relationship.h"
+
+namespace scc::translator::cypher {
+
+class Schema {
+public:
+  std::string database_name;
+
+  explicit Schema() = default;
+  explicit Schema(std::string database_name);
+
+private:
+  std::vector<Node> nodes;
+  std::vector<ConditionalRelationship> relationships;
+};
+
+} // scc::translator::cypher

--- a/include/SCC/translator/cypher/schema.h
+++ b/include/SCC/translator/cypher/schema.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "nlohmann/json.hpp"
+
 #include "SCC/translator/cypher/graph/node.h"
 #include "SCC/translator/cypher/graph/relationship.h"
 
@@ -17,6 +19,11 @@ public:
 
   explicit Schema() = default;
   explicit Schema(std::string database_name);
+
+  void AddNode(const Node& node);
+  void AddConditionalRelationship(const ConditionalRelationship& relationship);
+
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(Schema, database_name, nodes, relationships);
 
 private:
   std::vector<Node> nodes;

--- a/include/SCC/translator/schema/node.h
+++ b/include/SCC/translator/schema/node.h
@@ -1,14 +1,21 @@
 #pragma once
 
+#include <algorithm>
+#include <format>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <utility>
+
 #include "nlohmann/json.hpp"
 
-#include "SCC/translator/cypher/graph/node.h"
 #include "SCC/translator/schema/property.h"
 
 namespace scc::translator::schema {
 
-class Node : public cypher::BaseNode {
+class Node  {
 public:
+  std::string label;
   std::vector<Property> properties;
 
   explicit Node(std::string label);

--- a/include/SCC/translator/schema/node.h
+++ b/include/SCC/translator/schema/node.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "nlohmann/json.hpp"
+
+#include "SCC/translator/cypher/graph/node.h"
+#include "SCC/translator/schema/property.h"
+
+namespace scc::translator::schema {
+
+class Node : public cypher::BaseNode {
+public:
+  std::vector<Property> properties;
+
+  explicit Node(std::string label);
+  explicit Node(std::string label, std::vector<Property> properties);
+
+  Node& AddProperty(const Property& property);
+  bool HasProperty(const std::string& name) const;
+
+  bool operator==(const Node& other) const;
+  bool operator!=(const Node& other) const;
+};
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Node, label, properties)
+
+inline void to_json(nlohmann::json& j, const std::vector<Node>& nodes) {
+  j = nlohmann::json::array();
+  for (const auto& node : nodes) {
+    j.push_back(node);
+  }
+}
+inline void from_json(const nlohmann::json& j, std::vector<Node>& nodes) {
+  nodes = j.get<std::vector<Node>>();
+}
+
+} // scc::translator::schema

--- a/include/SCC/translator/schema/node.h
+++ b/include/SCC/translator/schema/node.h
@@ -23,6 +23,8 @@ public:
 
   Node& AddProperty(const Property& property);
   bool HasProperty(const std::string& name) const;
+  int PropertyIndex(const std::string& name) const;
+  unsigned PropertyCount() const;
 
   bool operator==(const Node& other) const;
   bool operator!=(const Node& other) const;

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -34,7 +34,7 @@ public:
                     std::vector<PropertyConstraint> constraints);
 
   void AddConstraint(const PropertyConstraint& constraint);
-  void RemoveConstraint(const PropertyConstraint& constraint);
+  void RemoveConstraintsByPrefix(const std::string& prefix);
   bool MustBeUnique() const;
   bool MustBeNotNull() const;
 

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "nlohmann/json.hpp"
+
+#include "SCC/translator/cypher/graph/constraint_types.h"
+#include "SCC/translator/cypher/graph/property.h"
+#include "SCC/translator/cypher/graph/property_types.h"
+
+namespace scc::translator::schema {
+
+class Property : public cypher::BaseProperty {
+public:
+  explicit Property(std::string name, cypher::PropertyType type);
+  explicit Property(std::string name, cypher::PropertyType type,
+                    std::vector<cypher::ConstraintType> constraints);
+
+  void AddConstraint(cypher::ConstraintType constraint);
+  void RemoveConstraint(cypher::ConstraintType constraint);
+  bool MustBeUnique() const;
+  bool MustBeNotNull() const;
+
+  bool operator==(const Property& other) const;
+  bool operator!=(const Property& other) const;
+
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(Property, name, type, constraints)
+
+private:
+  std::vector<cypher::ConstraintType> constraints;
+};
+
+inline void to_json(nlohmann::json& j, const std::vector<Property>& properties) {
+  j = nlohmann::json::array();
+  for (const auto& property : properties) {
+    j.push_back(property);
+  }
+}
+inline void from_json(const nlohmann::json& j, std::vector<Property>& properties) {
+  properties = j.get<std::vector<Property>>();
+}
+
+} // scc::translator::schema

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -22,7 +22,14 @@ public:
   }
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PropertyConstraint, name, type)
+inline void to_json(nlohmann::json& j, const PropertyConstraint& constraint)  {
+  j["name"] = constraint.name;
+  j["type"] = constraint.type.ToString();
+}
+inline void from_json(const nlohmann::json& j, PropertyConstraint& constraint) {
+  j.at("name").get_to(constraint.name);
+  j.at("type").get_to(constraint.type);
+}
 
 class Property {
 public:
@@ -41,7 +48,16 @@ public:
   bool operator==(const Property& other) const;
   bool operator!=(const Property& other) const;
 
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(Property, name, type, constraints)
+  friend void to_json(nlohmann::json& j, const Property& property) {
+    j["name"] = property.name;
+    j["type"] = property.type.ToString();
+    j["constraints"] = property.constraints;
+  }
+  friend void from_json(const nlohmann::json& j, Property& property) {
+    j.at("name").get_to(property.name);
+    j.at("type").get_to(property.type);
+    j.at("constraints").get_to(property.constraints);
+  }
 
 private:
   std::vector<PropertyConstraint> constraints;

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -1,15 +1,22 @@
 #pragma once
 
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <utility>
+
 #include "nlohmann/json.hpp"
 
 #include "SCC/translator/cypher/graph/constraint_types.h"
-#include "SCC/translator/cypher/graph/property.h"
 #include "SCC/translator/cypher/graph/property_types.h"
 
 namespace scc::translator::schema {
 
-class Property : public cypher::BaseProperty {
+class Property {
 public:
+  std::string name;
+  cypher::PropertyType type;
+
   explicit Property(std::string name, cypher::PropertyType type);
   explicit Property(std::string name, cypher::PropertyType type,
                     std::vector<cypher::ConstraintType> constraints);

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -12,6 +12,18 @@
 
 namespace scc::translator::schema {
 
+class PropertyConstraint {
+public:
+  std::string name;
+  cypher::ConstraintType type;
+
+  inline bool operator==(const PropertyConstraint& other) const {
+    return name == other.name && type == other.type;
+  }
+};
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PropertyConstraint, name, type)
+
 class Property {
 public:
   std::string name;
@@ -19,10 +31,10 @@ public:
 
   explicit Property(std::string name, cypher::PropertyType type);
   explicit Property(std::string name, cypher::PropertyType type,
-                    std::vector<cypher::ConstraintType> constraints);
+                    std::vector<PropertyConstraint> constraints);
 
-  void AddConstraint(cypher::ConstraintType constraint);
-  void RemoveConstraint(cypher::ConstraintType constraint);
+  void AddConstraint(const PropertyConstraint& constraint);
+  void RemoveConstraint(const PropertyConstraint& constraint);
   bool MustBeUnique() const;
   bool MustBeNotNull() const;
 
@@ -32,7 +44,10 @@ public:
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(Property, name, type, constraints)
 
 private:
-  std::vector<cypher::ConstraintType> constraints;
+  std::vector<PropertyConstraint> constraints;
+
+  bool HasConstraintType(cypher::ConstraintType type) const;
+  bool HasConstraint(const PropertyConstraint& constraint) const;
 };
 
 inline void to_json(nlohmann::json& j, const std::vector<Property>& properties) {

--- a/include/SCC/translator/schema/relationship.h
+++ b/include/SCC/translator/schema/relationship.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "nlohmann/json.hpp"
+
+#include "SCC/translator/cypher/graph/relationship.h"
+#include "SCC/translator/schema/node.h"
+#include "SCC/translator/schema/property.h"
+
+namespace scc::translator::schema {
+
+struct ApplyCondition {
+  int spi;
+  int epi;
+};
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ApplyCondition, spi, epi)
+
+constexpr bool operator==(const ApplyCondition& lhs, const ApplyCondition& rhs) {
+  return lhs.spi == rhs.spi && lhs.epi == rhs.epi;
+}
+
+class Relationship : public cypher::BaseRelationship {
+public:
+  Node start;
+  Node end;
+  std::vector<Property> properties;
+
+  explicit Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
+                        std::vector<ApplyCondition> conditions);
+
+  Relationship& AddCondition(ApplyCondition condition);
+
+  bool operator==(const Relationship& other) const;
+  bool operator!=(const Relationship& other) const;
+
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(Relationship, type, start, end, properties, conditions)
+
+private:
+  std::vector<ApplyCondition> conditions;
+};
+
+inline void to_json(nlohmann::json& j, const std::vector<Relationship>& relationships) {
+  j = nlohmann::json::array();
+  for (const auto& relationship : relationships) {
+    j.push_back(relationship);
+  }
+}
+inline void from_json(const nlohmann::json& j, std::vector<Relationship>& relationships) {
+  relationships = j.get<std::vector<Relationship>>();
+}
+
+} // scc::translator::schema

--- a/include/SCC/translator/schema/relationship.h
+++ b/include/SCC/translator/schema/relationship.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <utility>
 
@@ -28,10 +29,15 @@ public:
   Node end;
   std::vector<Property> properties;
 
+  explicit Relationship(std::string type, Node start, Node end);
+  explicit Relationship(std::string type, Node start, Node end,
+                        std::vector<ApplyCondition> conditions);
   explicit Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
                         std::vector<ApplyCondition> conditions);
 
   Relationship& AddCondition(ApplyCondition condition);
+  void RemoveConditionBySPI(int spi);
+  void RemoveConditionByEPI(int epi);
 
   bool operator==(const Relationship& other) const;
   bool operator!=(const Relationship& other) const;

--- a/include/SCC/translator/schema/relationship.h
+++ b/include/SCC/translator/schema/relationship.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <string>
+#include <utility>
+
 #include "nlohmann/json.hpp"
 
-#include "SCC/translator/cypher/graph/relationship.h"
 #include "SCC/translator/schema/node.h"
 #include "SCC/translator/schema/property.h"
 
@@ -19,8 +21,9 @@ constexpr bool operator==(const ApplyCondition& lhs, const ApplyCondition& rhs) 
   return lhs.spi == rhs.spi && lhs.epi == rhs.epi;
 }
 
-class Relationship : public cypher::BaseRelationship {
+class Relationship {
 public:
+  std::string type;
   Node start;
   Node end;
   std::vector<Property> properties;

--- a/include/SCC/translator/schema/relationship.h
+++ b/include/SCC/translator/schema/relationship.h
@@ -25,14 +25,11 @@ constexpr bool operator==(const ApplyCondition& lhs, const ApplyCondition& rhs) 
 class Relationship {
 public:
   std::string type;
-  Node start;
-  Node end;
-  std::vector<Property> properties;
+  std::string start;
+  std::string end;
 
-  explicit Relationship(std::string type, Node start, Node end);
-  explicit Relationship(std::string type, Node start, Node end,
-                        std::vector<ApplyCondition> conditions);
-  explicit Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
+  explicit Relationship(std::string type, std::string start, std::string end);
+  explicit Relationship(std::string type, std::string start, std::string end,
                         std::vector<ApplyCondition> conditions);
 
   Relationship& AddCondition(ApplyCondition condition);
@@ -42,7 +39,7 @@ public:
   bool operator==(const Relationship& other) const;
   bool operator!=(const Relationship& other) const;
 
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(Relationship, type, start, end, properties, conditions)
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(Relationship, type, start, end, conditions)
 
 private:
   std::vector<ApplyCondition> conditions;

--- a/include/SCC/translator/schema/schema.h
+++ b/include/SCC/translator/schema/schema.h
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <format>
+#include <functional>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -9,6 +11,7 @@
 #include "nlohmann/json.hpp"
 
 #include "SCC/translator/schema/node.h"
+#include "SCC/translator/schema/property.h"
 #include "SCC/translator/schema/relationship.h"
 
 namespace scc::translator::schema {
@@ -21,15 +24,29 @@ public:
   explicit Schema(std::string database_name);
 
   void AddNode(const Node& node);
-  void AddConditionalRelationship(const Relationship& relationship);
+  void AddNodeProperty(const std::string& label, const Property& property);
+  void AddNodePropertyConstraint(const std::string& label, const std::string& property_name,
+                                 const PropertyConstraint& constraint);
+  void AddRelationship(const Relationship& relationship);
 
-  std::string ToJsonString(const int indent = 2, const char indent_char = ' ') const;
+  std::optional<std::reference_wrapper<const Node>> FindNode(const std::string& label) const;
+  const Node& FindNodeOrThrow(const std::string& label) const;
+  std::optional<std::reference_wrapper<Node>> GetNode(const std::string& label);
+  Node& GetNodeOrThrow(const std::string& label);
+
+  void RemoveNode(const std::string& label);
+  void RemoveNodeProperty(const std::string& label, const std::string& property_name);
+  void Clear();
+
+  std::string ToJsonString(int indent = 2, char indent_char = ' ') const;
 
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(Schema, database_name, nodes, relationships);
 
 private:
   std::vector<Node> nodes;
   std::vector<Relationship> relationships;
+
+  void RemovePropertyIdxFromConditions(const std::string& label, int pi);
 };
 
 } // scc::translator::cypher

--- a/include/SCC/translator/schema/schema.h
+++ b/include/SCC/translator/schema/schema.h
@@ -8,10 +8,10 @@
 
 #include "nlohmann/json.hpp"
 
-#include "SCC/translator/cypher/graph/node.h"
-#include "SCC/translator/cypher/graph/relationship.h"
+#include "SCC/translator/schema/node.h"
+#include "SCC/translator/schema/relationship.h"
 
-namespace scc::translator::cypher {
+namespace scc::translator::schema {
 
 class Schema {
 public:
@@ -21,13 +21,13 @@ public:
   explicit Schema(std::string database_name);
 
   void AddNode(const Node& node);
-  void AddConditionalRelationship(const ConditionalRelationship& relationship);
+  void AddConditionalRelationship(const Relationship& relationship);
 
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(Schema, database_name, nodes, relationships);
 
 private:
   std::vector<Node> nodes;
-  std::vector<ConditionalRelationship> relationships;
+  std::vector<Relationship> relationships;
 };
 
 } // scc::translator::cypher

--- a/include/SCC/translator/schema/schema.h
+++ b/include/SCC/translator/schema/schema.h
@@ -36,6 +36,8 @@ public:
 
   void RemoveNode(const std::string& label);
   void RemoveNodeProperty(const std::string& label, const std::string& property_name);
+  void RemoveNodePropertyConstraints(const std::string& label, const std::string& constraint_name);
+  void RemoveRelationship(const std::string& type);
   void Clear();
 
   std::string ToJsonString(int indent = 2, char indent_char = ' ') const;

--- a/include/SCC/translator/schema/schema.h
+++ b/include/SCC/translator/schema/schema.h
@@ -23,6 +23,8 @@ public:
   void AddNode(const Node& node);
   void AddConditionalRelationship(const Relationship& relationship);
 
+  std::string ToJsonString(const int indent = 2, const char indent_char = ' ') const;
+
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(Schema, database_name, nodes, relationships);
 
 private:

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -15,10 +15,6 @@
 #include "SCC/config/scc_config.h"
 #include "SCC/log/log.h"
 #include "SCC/parser/parser.h"
-#include "SCC/translator/cypher/clauses/create.h"
-#include "SCC/translator/cypher/clauses/delete.h"
-#include "SCC/translator/cypher/clauses/drop.h"
-#include "SCC/translator/cypher/clauses/set.h"
 #include "SCC/translator/schema/node.h"
 #include "SCC/translator/schema/property.h"
 #include "SCC/translator/schema/relationship.h"
@@ -71,9 +67,9 @@ private:
   void TranslateAlterTableActionDrop(const std::shared_ptr<ast::INode>& action_node,
                                      std::string& table_name);
 
-  std::vector<cypher::Property> TranslateColumnDefinitions(
+  std::vector<schema::Property> TranslateColumnDefinitions(
       const std::shared_ptr<ast::INode>& column_definition);
-  cypher::Property TranslateColumnDefinition(const std::shared_ptr<ast::INode>& node);
+  schema::Property TranslateColumnDefinition(const std::shared_ptr<ast::INode>& node);
   void TranslateTableConstraint(const std::shared_ptr<ast::INode>& constraint_definition,
                                 const std::string& table_name);
 
@@ -101,7 +97,6 @@ private:
   void AddRelationship(const std::string& relationship_type,
                        const std::string& start_label, const std::string& end_label,
                        const std::vector<schema::ApplyCondition>& apply_conditions);
-  void RemoveNodeProperty(const std::string& label, const std::string& property_name);
 
   std::vector<schema::ApplyCondition> CreateApplyConditions(
       const std::string& start_label, const std::vector<std::string>& start_node_props,

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -19,6 +19,7 @@
 #include "SCC/translator/cypher/clauses/delete.h"
 #include "SCC/translator/cypher/clauses/drop.h"
 #include "SCC/translator/cypher/clauses/set.h"
+#include "SCC/translator/schema/schema.h"
 
 #include "logger/log.hpp"
 
@@ -29,17 +30,16 @@ public:
   explicit translation_error(const std::string& message);
 };
 
-// Column as property with standard data
-using StdProperty = std::tuple<std::string, std::string>;
-
 class Translator {
 public:
   explicit Translator(std::shared_ptr<ast::INode> ast, const std::filesystem::path& out_path);
 
-  void Translate();
+  void Translate(bool translate_schema);
 
 private:
   std::shared_ptr<ast::INode> ast_;
+  schema::Schema schema_;
+  std::filesystem::path schema_path_;
   std::ofstream out_;
 
   int constraint_counter = 0;

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -90,17 +90,14 @@ private:
   std::string GetName(const std::shared_ptr<ast::INode>& name_node) const;
   std::string GetIdentifier(const std::shared_ptr<ast::INode>& node) const;
 
-  void CreateConstraint(const std::string& constraint_name,
-                        const std::string& label_name,
-                        const std::string& property_name,
-                        cypher::ConstraintType constraint_type);
+  void CreateConstraints(const std::string& constraint_name_prefix, const std::string& label_name,
+                         const std::string& property_name,
+                         const std::vector<cypher::ConstraintType>& constraints);
   void CreateRelationship(const std::string& relationship_type, const std::string& start_label_name,
                           const std::string& end_label_name);
   void RemoveProperty(const std::string& label_name, const std::string& property_name);
   std::string CreateRelationshipType(const std::string& type_prefix);
   std::string CreatePrimaryKeyConstraintName(const std::string& table_name) const;
-  std::string CreateForeignKeyConstraintName(const std::string& table_name,
-                                             const std::string& ref_table_name) const;
 
   // Validation
 

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -19,6 +19,9 @@
 #include "SCC/translator/cypher/clauses/delete.h"
 #include "SCC/translator/cypher/clauses/drop.h"
 #include "SCC/translator/cypher/clauses/set.h"
+#include "SCC/translator/schema/node.h"
+#include "SCC/translator/schema/property.h"
+#include "SCC/translator/schema/relationship.h"
 #include "SCC/translator/schema/schema.h"
 
 #include "logger/log.hpp"
@@ -92,14 +95,24 @@ private:
   std::string GetName(const std::shared_ptr<ast::INode>& name_node) const;
   std::string GetIdentifier(const std::shared_ptr<ast::INode>& node) const;
 
-  void CreateConstraints(const std::string& constraint_name_prefix, const std::string& label_name,
-                         const std::string& property_name,
-                         const std::vector<cypher::ConstraintType>& constraints);
-  void CreateRelationship(const std::string& relationship_type, const std::string& start_label_name,
-                          const std::string& end_label_name);
-  void RemoveProperty(const std::string& label_name, const std::string& property_name);
+  void AddPropertyConstraints(const std::string& constraint_name_prefix, const std::string& label,
+                              const std::string& property_name,
+                              const std::vector<cypher::ConstraintType>& constraint_types);
+  void AddRelationship(const std::string& relationship_type,
+                       const std::string& start_label, const std::string& end_label,
+                       const std::vector<schema::ApplyCondition>& apply_conditions);
+  void RemoveNodeProperty(const std::string& label, const std::string& property_name);
+
+  std::vector<schema::ApplyCondition> CreateApplyConditions(
+      const std::string& start_label, const std::vector<std::string>& start_node_props,
+      const std::string& end_label, const std::vector<std::string>& end_node_props
+  );
   std::string CreateRelationshipType(const std::string& type_prefix);
-  std::string CreatePrimaryKeyConstraintName(const std::string& table_name) const;
+  std::string CreatePKConstraintPrefix(const std::string& table_name) const;
+  std::string CreateFKConstraintPrefix(const std::string& table_name,
+                                       const std::string& ref_table_name) const;
+
+  const schema::Node& GetNodeFromSchema(const std::string& label) const;
 
   // Validation
 

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -66,9 +66,9 @@ private:
   void TranslateAlterTableActionDrop(const std::shared_ptr<ast::INode>& action_node,
                                      std::string& table_name);
 
-  std::vector<cypher::NodeProperty> TranslateColumnDefinitions(
+  std::vector<cypher::Property> TranslateColumnDefinitions(
       const std::shared_ptr<ast::INode>& column_definition);
-  cypher::NodeProperty TranslateColumnDefinition(const std::shared_ptr<ast::INode>& node);
+  cypher::Property TranslateColumnDefinition(const std::shared_ptr<ast::INode>& node);
   void TranslateTableConstraint(const std::shared_ptr<ast::INode>& constraint_definition,
                                 const std::string& table_name);
 

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -32,12 +32,14 @@ public:
 
 class Translator {
 public:
-  explicit Translator(std::shared_ptr<ast::INode> ast, const std::filesystem::path& out_path);
+  explicit Translator(std::shared_ptr<ast::INode> ast, const std::filesystem::path& out_path,
+                      bool translate_schema);
 
-  void Translate(bool translate_schema);
+  void Translate();
 
 private:
   std::shared_ptr<ast::INode> ast_;
+  bool translate_schema_;
   schema::Schema schema_;
   std::filesystem::path schema_path_;
   std::ofstream out_;

--- a/src/ast_handler.cpp
+++ b/src/ast_handler.cpp
@@ -1,1 +1,0 @@
-#include "SCC/ast_handler.h"

--- a/src/config/scc_args.cpp
+++ b/src/config/scc_args.cpp
@@ -30,6 +30,11 @@ SCCArgs::SCCArgs() : ArgumentParser(PROGRAM_NAME, VERSION, argparse::default_arg
       .implicit_value(true)
       .nargs(0);
 
+  add_argument("--translate-schema")
+      .help("Use this option to translate SQL schema migration queries into Cypher")
+      .default_value(true)
+      .implicit_value(true);
+
   add_argument("--sql")
       .required()
       .help("Specify path to the file with SQL queries to be converted")

--- a/src/config/scc_args.cpp
+++ b/src/config/scc_args.cpp
@@ -35,7 +35,7 @@ SCCArgs::SCCArgs() : ArgumentParser(PROGRAM_NAME, VERSION, argparse::default_arg
       .help("Specify path to the file with SQL queries to be converted")
       .metavar("FILENAME");
 
-  std::string default_cypher_file = (std::filesystem::current_path() / "out.cypher").string();
+  std::string default_cypher_file = (std::filesystem::current_path() / "out.cql").string();
   add_argument("--cypher")
       .help("Specify path to the file with the result CypherQL queries")
       .metavar("FILENAME")

--- a/src/config/scc_config.cpp
+++ b/src/config/scc_config.cpp
@@ -30,6 +30,8 @@ SCCConfig::SCCConfig(const SCCArgs& args) {
     else
       mode = args.Get<SCCMode>("--mode");
 
+    translate_schema = args.Get<bool>("--translate-schema");
+
     std::string sql_file_path = args.Get("--sql");
     scc::common::ValidateFileExists(sql_file_path);
     sql_file_ = fs::canonical(sql_file_path);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,9 @@ int main(int argc, char* argv[]) {
       dump.DumpTree(AST);
     }
 
-    scc::translator::Translator translator(AST, config->get_cypher_file());
-    translator.Translate(config->translate_schema);
+    scc::translator::Translator translator(AST, config->get_cypher_file(),
+                                           config->translate_schema);
+    translator.Translate();
 
     end(EXIT_SUCCESS);
   } catch (const std::exception& e) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
     }
 
     scc::translator::Translator translator(AST, config->get_cypher_file());
-    translator.Translate();
+    translator.Translate(config->translate_schema);
 
     end(EXIT_SUCCESS);
   } catch (const std::exception& e) {

--- a/src/translator/CMakeLists.txt
+++ b/src/translator/CMakeLists.txt
@@ -3,6 +3,7 @@ set(DIRS
         cypher
         ddl
         dml
+        schema
 )
 foreach(DIR ${DIRS})
     add_subdirectory(${DIR})
@@ -15,7 +16,9 @@ target_sources(scc_translator PRIVATE
 target_link_libraries(scc_translator PRIVATE scc_include)
 target_link_libraries(scc_translator PUBLIC
         scc_translator_common
-        scc_translator_cypher
+        scc_translator_cypher_clauses
+        scc_translator_cypher_graph
         scc_translator_ddl
         scc_translator_dml
+        scc_translator_schema
 )

--- a/src/translator/CMakeLists.txt
+++ b/src/translator/CMakeLists.txt
@@ -15,8 +15,7 @@ target_sources(scc_translator PRIVATE
 target_link_libraries(scc_translator PRIVATE scc_include)
 target_link_libraries(scc_translator PUBLIC
         scc_translator_common
-        scc_translator_cypher_clauses
-        scc_translator_cypher_graph
+        scc_translator_cypher
         scc_translator_ddl
         scc_translator_dml
 )

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -104,7 +104,7 @@ void Translator::CreateRelationship(const std::string& relationship_type,
                                     const std::string& end_label_name) {
   Node start_node(start_label_name, "a"), end_node(end_label_name, "b");
   Relationship relationship(relationship_type, start_node, end_node,
-                            Relationship::Direction::kRight);
+                            Direction::kRight);
   WriteCypherQuery(CreateRelationshipClauseBuilder::Build(relationship));
 }
 void Translator::RemoveProperty(const std::string& label_name, const std::string& property_name) {

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -116,9 +116,6 @@ void Translator::AddRelationship(const std::string& relationship_type,
   Relationship relationship(relationship_type, start, end, apply_conditions);
   schema_.AddRelationship(relationship);
 }
-void Translator::RemoveNodeProperty(const std::string& label, const std::string& property_name) {
-  schema_.RemoveNodeProperty(label, property_name);
-}
 
 std::vector<ApplyCondition> Translator::CreateApplyConditions(
     const std::string& start_label, const std::vector<std::string>& start_node_props,

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -112,8 +112,7 @@ void Translator::AddPropertyConstraints(const std::string& constraint_name_prefi
 void Translator::AddRelationship(const std::string& relationship_type,
                                  const std::string& start_label, const std::string& end_label,
                                  const std::vector<ApplyCondition>& apply_conditions) {
-  Node start(start_label), end(end_label);
-  Relationship relationship(relationship_type, start, end, apply_conditions);
+  Relationship relationship(relationship_type, start_label, end_label, apply_conditions);
   schema_.AddRelationship(relationship);
 }
 

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -92,7 +92,7 @@ void Translator::CreateConstraint(const std::string& constraint_name,
                                   const std::string& property_name,
                                   ConstraintType constraint_type) {
   Node node(label_name);
-  NodeProperty property(property_name, std::string(stub_str), PropertyType::kUnknown);
+  Property property(property_name, std::string(stub_str), PropertyType::kUnknown);
 
   WriteCypherQuery(
       CreateConstraintClauseBuilder::Build(constraint_name, node, property, constraint_type)

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -4,11 +4,10 @@ namespace scc::translator {
 
 using namespace ast;
 using namespace ast::common;
-using namespace cypher;
+using namespace schema;
 
-template<typename NodeType,
-    typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
-using NodePtr = std::shared_ptr<NodeType>;
+using cypher::ConstraintType;
+using cypher::PropertyType;
 
 void Translator::TranslatePrimaryKey(const NodePtr<INode>& primary_key,
                                      const std::string& constraint_name,

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -6,10 +6,15 @@ using namespace ast;
 using namespace ast::common;
 using namespace schema;
 
+using std::format;
 using cypher::ConstraintType;
 using cypher::PropertyType;
 
-void Translator::TranslatePrimaryKey(const NodePtr<INode>& primary_key,
+template<typename ASTNodeType,
+    typename std::enable_if<std::is_base_of<INode, ASTNodeType>::value>::type* = nullptr>
+using ASTNodePtr = std::shared_ptr<ASTNodeType>;
+
+void Translator::TranslatePrimaryKey(const ASTNodePtr<INode>& primary_key,
                                      const std::string& constraint_name,
                                      const std::string& table_name) {
   for (unsigned i = 0; HasChildren(primary_key, i + 1); ++i) {
@@ -18,12 +23,12 @@ void Translator::TranslatePrimaryKey(const NodePtr<INode>& primary_key,
     auto column_name = GetName(column_name_node);
 
     std::string constraint_name_prefix = constraint_name.empty()
-        ? CreatePrimaryKeyConstraintName(table_name) : constraint_name;
-    CreateConstraints(constraint_name_prefix, table_name, column_name,
-                      {ConstraintType::kUniqueness, ConstraintType::kExistence});
+        ? CreatePKConstraintPrefix(table_name) : constraint_name;
+    AddPropertyConstraints(constraint_name_prefix, table_name, column_name,
+                           {ConstraintType::kUniqueness, ConstraintType::kExistence});
   }
 }
-void Translator::TranslateForeignKey(const NodePtr<INode>& foreign_key,
+void Translator::TranslateForeignKey(const ASTNodePtr<INode>& foreign_key,
                                      const std::string& constraint_name,
                                      const std::string& table_name) {
   std::vector<std::string> properties;
@@ -58,6 +63,12 @@ void Translator::TranslateForeignKey(const NodePtr<INode>& foreign_key,
     ref_columns.push_back(column_name);
   }
 
+  if (properties.size() != ref_columns.size()) {
+    std::string msg = format("Wrong number of columns for foreign key. Expected {}, got {}",
+                                  properties.size(), ref_columns.size());
+    throw translation_error(msg);
+  }
+
   // TODO: Match all nodes with correspond labels and remove properties.
 //  for (const auto& property: properties) {
 //    RemoveProperty(table_name, property);
@@ -65,12 +76,16 @@ void Translator::TranslateForeignKey(const NodePtr<INode>& foreign_key,
 //  for (const auto& ref_property: ref_columns) {
 //    RemoveProperty(ref_table_name, ref_property);
 //  }
+
+  auto apply_conditions = CreateApplyConditions(table_name, properties,
+                                                ref_table_name, ref_columns);
   std::string relationship_type = constraint_name.empty()
-      ? CreateRelationshipType(CreatePrimaryKeyConstraintName(table_name)) : constraint_name;
-  CreateRelationship(relationship_type, table_name, ref_table_name);
+      ? CreateRelationshipType(CreateFKConstraintPrefix(table_name, ref_table_name))
+      : constraint_name;
+  AddRelationship(relationship_type, table_name, ref_table_name, apply_conditions);
 }
 
-std::string Translator::GetName(const NodePtr<INode>& name_node) const {
+std::string Translator::GetName(const ASTNodePtr<INode>& name_node) const {
   std::ostringstream name;
   ValidateHasChildren(name_node);
   for (unsigned i = 0; HasChildren(name_node, i + 1); ++i) {
@@ -80,45 +95,66 @@ std::string Translator::GetName(const NodePtr<INode>& name_node) const {
   }
   return name.str();
 }
-std::string Translator::GetIdentifier(const NodePtr<INode>& node) const {
+std::string Translator::GetIdentifier(const ASTNodePtr<INode>& node) const {
   return ASTUtils::CastToNodeType<StringNode>(node->Child(0))->data;
 }
 
-void Translator::CreateConstraints(const std::string& constraint_name_prefix,
-                                   const std::string& label_name, const std::string& property_name,
-                                   const std::vector<ConstraintType>& constraints) {
-  Node node(label_name);
-  Property property(property_name, std::string(stub_str), PropertyType::kUnknown);
-
-  for (const auto& constraint : constraints) {
-    std::string constraint_name = std::format("{}_{}", constraint_name_prefix, constraint_counter);
-    WriteCypherQuery(
-        CreateConstraintClauseBuilder::Build(constraint_name, node, property, constraint)
-    );
+void Translator::AddPropertyConstraints(const std::string& constraint_name_prefix,
+                                        const std::string& label, const std::string& property_name,
+                                        const std::vector<ConstraintType>& constraint_types) {
+  for (const auto& constraint_type : constraint_types) {
+    std::string constraint_name = format("{}{}", constraint_name_prefix, constraint_counter);
+    schema_.AddNodePropertyConstraint(label, property_name,
+                                      PropertyConstraint(constraint_name, constraint_type));
     constraint_counter++;
   }
 }
-void Translator::CreateRelationship(const std::string& relationship_type,
-                                    const std::string& start_label_name,
-                                    const std::string& end_label_name) {
-  Node start_node(start_label_name, "a"), end_node(end_label_name, "b");
-  Relationship relationship(relationship_type, start_node, end_node,
-                            Direction::kRight);
-  WriteCypherQuery(CreateRelationshipClauseBuilder::Build(relationship));
+void Translator::AddRelationship(const std::string& relationship_type,
+                                 const std::string& start_label, const std::string& end_label,
+                                 const std::vector<ApplyCondition>& apply_conditions) {
+  Node start(start_label), end(end_label);
+  Relationship relationship(relationship_type, start, end, apply_conditions);
+  schema_.AddRelationship(relationship);
 }
-void Translator::RemoveProperty(const std::string& label_name, const std::string& property_name) {
-  Node node(label_name, "n");
-  WriteCypherQuery(RemovePropertyClauseBuilder::Build(node, property_name));
+void Translator::RemoveNodeProperty(const std::string& label, const std::string& property_name) {
+  schema_.RemoveNodeProperty(label, property_name);
+}
+
+std::vector<ApplyCondition> Translator::CreateApplyConditions(
+    const std::string& start_label, const std::vector<std::string>& start_node_props,
+    const std::string& end_label, const std::vector<std::string>& end_node_props
+) {
+  const auto& start_node = GetNodeFromSchema(start_label);
+  const auto& end_node = GetNodeFromSchema(end_label);
+  std::vector<ApplyCondition> apply_conditions;
+  for (unsigned i = 0; i < start_node_props.size(); ++i) {
+    int spi = start_node.PropertyIndex(start_node_props[i]);
+    int epi = end_node.PropertyIndex(end_node_props[i]);
+    apply_conditions.push_back({spi, epi});
+  }
+  return apply_conditions;
 }
 std::string Translator::CreateRelationshipType(const std::string& type_prefix) {
-  std::stringstream ss;
-  ss << type_prefix << "_" << relationship_counter;
+  std::string type = format("{}{}", type_prefix, relationship_counter);
   relationship_counter++;
-
-  return ss.str();
+  return type;
 }
-std::string Translator::CreatePrimaryKeyConstraintName(const std::string& table_name) const {
-  return table_name + "_constraint";
+std::string Translator::CreatePKConstraintPrefix(const std::string& table_name) const {
+  return format("{}_pk_", table_name);
+}
+std::string Translator::CreateFKConstraintPrefix(const std::string& table_name,
+                                                 const std::string& ref_table_name) const {
+  return format("fk_{}_to_{}_", table_name, ref_table_name);
+}
+
+const Node& Translator::GetNodeFromSchema(const std::string& label) const {
+  try {
+    const Node& node = schema_.FindNodeOrThrow(label);
+    return node;
+  } catch (std::runtime_error& e) {
+    std::string msg = format("Table {} not found", label);
+    throw translation_error(msg);
+  }
 }
 
 } // scc::translator

--- a/src/translator/common/basic_statements.cpp
+++ b/src/translator/common/basic_statements.cpp
@@ -20,10 +20,8 @@ void Translator::TranslatePrimaryKey(const NodePtr<INode>& primary_key,
 
     std::string constraint_name_prefix = constraint_name.empty()
         ? CreatePrimaryKeyConstraintName(table_name) : constraint_name;
-    CreateConstraint(constraint_name_prefix + "_" + std::to_string(constraint_counter++),
-                     table_name, column_name, ConstraintType::kUniqueness);
-    CreateConstraint(constraint_name_prefix + "_" + std::to_string(constraint_counter++),
-                     table_name, column_name, ConstraintType::kExistence);
+    CreateConstraints(constraint_name_prefix, table_name, column_name,
+                      {ConstraintType::kUniqueness, ConstraintType::kExistence});
   }
 }
 void Translator::TranslateForeignKey(const NodePtr<INode>& foreign_key,
@@ -87,16 +85,19 @@ std::string Translator::GetIdentifier(const NodePtr<INode>& node) const {
   return ASTUtils::CastToNodeType<StringNode>(node->Child(0))->data;
 }
 
-void Translator::CreateConstraint(const std::string& constraint_name,
-                                  const std::string& label_name,
-                                  const std::string& property_name,
-                                  ConstraintType constraint_type) {
+void Translator::CreateConstraints(const std::string& constraint_name_prefix,
+                                   const std::string& label_name, const std::string& property_name,
+                                   const std::vector<ConstraintType>& constraints) {
   Node node(label_name);
   Property property(property_name, std::string(stub_str), PropertyType::kUnknown);
 
-  WriteCypherQuery(
-      CreateConstraintClauseBuilder::Build(constraint_name, node, property, constraint_type)
-  );
+  for (const auto& constraint : constraints) {
+    std::string constraint_name = std::format("{}_{}", constraint_name_prefix, constraint_counter);
+    WriteCypherQuery(
+        CreateConstraintClauseBuilder::Build(constraint_name, node, property, constraint)
+    );
+    constraint_counter++;
+  }
 }
 void Translator::CreateRelationship(const std::string& relationship_type,
                                     const std::string& start_label_name,
@@ -119,10 +120,6 @@ std::string Translator::CreateRelationshipType(const std::string& type_prefix) {
 }
 std::string Translator::CreatePrimaryKeyConstraintName(const std::string& table_name) const {
   return table_name + "_constraint";
-}
-std::string Translator::CreateForeignKeyConstraintName(const std::string& table_name,
-                                                       const std::string& ref_table_name) const {
-  return "fk_" + table_name + "_to_" + ref_table_name;
 }
 
 } // scc::translator

--- a/src/translator/cypher/CMakeLists.txt
+++ b/src/translator/cypher/CMakeLists.txt
@@ -5,3 +5,15 @@ set(DIRS
 foreach(DIR ${DIRS})
     add_subdirectory(${DIR})
 endforeach()
+
+add_library(scc_translator_cypher STATIC)
+target_sources(scc_translator_cypher PRIVATE
+        schema.cpp
+)
+target_link_libraries(scc_translator_cypher PRIVATE
+        scc_include
+)
+target_link_libraries(scc_parser PUBLIC
+        scc_translator_cypher_clauses
+        scc_translator_cypher_graph
+)

--- a/src/translator/cypher/CMakeLists.txt
+++ b/src/translator/cypher/CMakeLists.txt
@@ -13,7 +13,7 @@ target_sources(scc_translator_cypher PRIVATE
 target_link_libraries(scc_translator_cypher PRIVATE
         scc_include
 )
-target_link_libraries(scc_parser PUBLIC
+target_link_libraries(scc_translator_cypher PUBLIC
         scc_translator_cypher_clauses
         scc_translator_cypher_graph
 )

--- a/src/translator/cypher/CMakeLists.txt
+++ b/src/translator/cypher/CMakeLists.txt
@@ -5,15 +5,3 @@ set(DIRS
 foreach(DIR ${DIRS})
     add_subdirectory(${DIR})
 endforeach()
-
-add_library(scc_translator_cypher STATIC)
-target_sources(scc_translator_cypher PRIVATE
-        schema.cpp
-)
-target_link_libraries(scc_translator_cypher PRIVATE
-        scc_include
-)
-target_link_libraries(scc_translator_cypher PUBLIC
-        scc_translator_cypher_clauses
-        scc_translator_cypher_graph
-)

--- a/src/translator/cypher/clauses/create.cpp
+++ b/src/translator/cypher/clauses/create.cpp
@@ -24,7 +24,7 @@ std::string CreateConstraintClauseBuilder::Build(const std::string& constraint_n
   std::string variable_name = node.variable.empty() ? std::string(kDefaultVar) : node.variable;
   ss << "FOR (" << variable_name;
   for (const auto& label : node.labels) {
-    ss << label.ToString();
+    ss << ":" << label;
   }
   ss << ")" << "\n";
 

--- a/src/translator/cypher/clauses/create.cpp
+++ b/src/translator/cypher/clauses/create.cpp
@@ -11,7 +11,7 @@ std::string CreateNodeClauseBuilder::Build(const Node& node) {
 }
 
 std::string CreateConstraintClauseBuilder::Build(const std::string& constraint_name,
-                                                 const Node& node, const NodeProperty& property,
+                                                 const Node& node, const Property& property,
                                                  ConstraintType type) {
   if (type == ConstraintType::kNone) {
     throw std::invalid_argument("Could not build \'CREATE CONSTRAINT\' clause for \'"

--- a/src/translator/cypher/clauses/create.cpp
+++ b/src/translator/cypher/clauses/create.cpp
@@ -2,6 +2,8 @@
 
 namespace scc::translator::cypher {
 
+using std::format;
+
 std::string CreateDatabaseClauseBuilder::Build(const std::string& database_name) {
   return "CREATE DATABASE " + database_name;
 }
@@ -14,8 +16,9 @@ std::string CreateConstraintClauseBuilder::Build(const std::string& constraint_n
                                                  const Node& node, const Property& property,
                                                  ConstraintType type) {
   if (type == ConstraintType::kNone) {
-    throw std::invalid_argument("Could not build \'CREATE CONSTRAINT\' clause for \'"
-                                    + type.ToString() + "\' cypher constraint type");
+    std::string msg = format("Could not build \'CREATE CONSTRAINT\' clause "
+                             "for \'{}\' cypher constraint type", type.ToString());
+    throw std::invalid_argument(msg);
   }
 
   std::stringstream ss;
@@ -23,9 +26,7 @@ std::string CreateConstraintClauseBuilder::Build(const std::string& constraint_n
 
   std::string variable_name = node.variable.empty() ? std::string(kDefaultVar) : node.variable;
   ss << "FOR (" << variable_name;
-  for (const auto& label : node.labels) {
-    ss << ":" << label;
-  }
+  ss << ":" << node.label;
   ss << ")" << "\n";
 
   ss << "REQUIRE (" << variable_name << "." << property.name << ")";

--- a/src/translator/cypher/clauses/set.cpp
+++ b/src/translator/cypher/clauses/set.cpp
@@ -2,7 +2,7 @@
 
 namespace scc::translator::cypher {
 
-std::string SetPropertyClauseBuilder::Build(const Node& node, const NodeProperty& property) {
+std::string SetPropertyClauseBuilder::Build(const Node& node, const Property& property) {
   std::stringstream ss;
   ss << "MATCH " << node.ToString() << "\n";
   ss << "SET " << node.variable << "." << property.name << " = " << property.value;

--- a/src/translator/cypher/graph/CMakeLists.txt
+++ b/src/translator/cypher/graph/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(scc_translator_cypher_graph STATIC)
 target_sources(scc_translator_cypher_graph PRIVATE
         constraint_types.cpp
         node.cpp
+        property.cpp
         property_types.cpp
         relationship.cpp
 )

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -5,13 +5,14 @@ namespace scc::translator::cypher {
 using std::format;
 
 Node::Node(std::string label)
-    : BaseNode::BaseNode(std::move(label), {}) {}
+    : BaseNode::BaseNode(std::move(label)) {}
 Node::Node(std::string label, std::string variable)
-    : BaseNode::BaseNode(std::move(label), {}), variable(std::move(variable)) {}
+    : BaseNode::BaseNode(std::move(label)), variable(std::move(variable)) {}
 Node::Node(std::string label, std::vector<Property> properties)
-    : BaseNode::BaseNode(std::move(label), std::move(properties)) {}
+    : BaseNode::BaseNode(std::move(label)), properties(std::move(properties)) {}
 Node::Node(std::string label, std::vector<Property> properties, std::string variable)
-    : BaseNode::BaseNode(std::move(label), std::move(properties)), variable(std::move(variable)) {}
+    : BaseNode::BaseNode(std::move(label)), properties(std::move(properties)),
+      variable(std::move(variable)) {}
 
 Node& Node::AddProperty(const Property& property) {
   if (HasProperty(property.name)) {

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -17,18 +17,18 @@ bool operator<(const Label& lhs, const Label& rhs) {
   return lhs.value < rhs.value;
 }
 
-NodeProperty::NodeProperty(std::string  name, std::string value, PropertyType type)
+Property::Property(std::string  name, std::string value, PropertyType type)
     : name(std::move(name)), value(std::move(value)), type(type) {}
 
-std::string NodeProperty::ToString() const {
+std::string Property::ToString() const {
   return name + ": " + value;
 }
 
-std::ostream& operator<<(std::ostream& os, const NodeProperty &property) {
+std::ostream& operator<<(std::ostream& os, const Property &property) {
   os << property.ToString();
   return os;
 }
-bool operator<(const NodeProperty& lhs, const NodeProperty& rhs) {
+bool operator<(const Property& lhs, const Property& rhs) {
   if (lhs.type != rhs.type) {
     return lhs.type < rhs.type;
   }
@@ -41,13 +41,13 @@ Node::Node(std::string label_name, std::string variable)
     : labels({Label(std::move(label_name))}), variable(std::move(variable)) {}
 Node::Node(Label label)
     : labels({std::move(label)}) {}
-Node::Node(Label label, std::vector<NodeProperty> properties)
+Node::Node(Label label, std::vector<Property> properties)
     : labels({std::move(label)}), properties(std::move(properties)) {}
-Node::Node(Label label, std::vector<NodeProperty> properties, std::string variable)
+Node::Node(Label label, std::vector<Property> properties, std::string variable)
     : labels({std::move(label)}), properties(std::move(properties)),
       variable(std::move(variable)) {}
 
-Node& Node::AddProperty(const NodeProperty& property) {
+Node& Node::AddProperty(const Property& property) {
   properties.push_back(property);
   return *this;
 }
@@ -56,7 +56,7 @@ Node& Node::AddProperty(const std::string& name, const std::string& value, Prope
   return *this;
 }
 bool Node::HasProperty(const std::string& name) const {
-  static auto predicate = [name](const NodeProperty& property) { return property.name == name; };
+  static auto predicate = [name](const Property& property) { return property.name == name; };
   return std::find_if(properties.begin(), properties.end(), predicate) != properties.end();
 }
 unsigned Node::PropertyCount() const {

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -17,24 +17,6 @@ bool operator<(const Label& lhs, const Label& rhs) {
   return lhs.value < rhs.value;
 }
 
-Property::Property(std::string  name, std::string value, PropertyType type)
-    : name(std::move(name)), value(std::move(value)), type(type) {}
-
-std::string Property::ToString() const {
-  return name + ": " + value;
-}
-
-std::ostream& operator<<(std::ostream& os, const Property &property) {
-  os << property.ToString();
-  return os;
-}
-bool operator<(const Property& lhs, const Property& rhs) {
-  if (lhs.type != rhs.type) {
-    return lhs.type < rhs.type;
-  }
-  return lhs.name < rhs.name;
-}
-
 Node::Node(std::string label_name)
     : labels({Label(std::move(label_name))}) {}
 Node::Node(std::string label_name, std::string variable)

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -5,14 +5,13 @@ namespace scc::translator::cypher {
 using std::format;
 
 Node::Node(std::string label)
-    : BaseNode::BaseNode(std::move(label)) {}
+    : label(std::move(label)) {}
 Node::Node(std::string label, std::string variable)
-    : BaseNode::BaseNode(std::move(label)), variable(std::move(variable)) {}
+    : label(std::move(label)), variable(std::move(variable)) {}
 Node::Node(std::string label, std::vector<Property> properties)
-    : BaseNode::BaseNode(std::move(label)), properties(std::move(properties)) {}
+    : label(std::move(label)), properties(std::move(properties)) {}
 Node::Node(std::string label, std::vector<Property> properties, std::string variable)
-    : BaseNode::BaseNode(std::move(label)), properties(std::move(properties)),
-      variable(std::move(variable)) {}
+    : label(std::move(label)), properties(std::move(properties)), variable(std::move(variable)) {}
 
 Node& Node::AddProperty(const Property& property) {
   if (HasProperty(property.name)) {

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -2,18 +2,18 @@
 
 namespace scc::translator::cypher {
 
-Label::Label(std::string name)
+Node::Label::Label(std::string name)
     : value(std::move(name)) {}
 
-std::string Label::ToString() const {
+std::string Node::Label::ToString() const {
   return ":" + value;
 }
 
-std::ostream& operator<<(std::ostream& os, const Label& label) {
+std::ostream& operator<<(std::ostream& os, const Node::Label& label) {
   os << label.ToString();
   return os;
 }
-bool operator<(const Label& lhs, const Label& rhs) {
+bool operator<(const Node::Label& lhs, const Node::Label& rhs) {
   return lhs.value < rhs.value;
 }
 

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -27,8 +27,8 @@ Node& Node::AddProperty(const std::string& name, const std::string& value, Prope
   return *this;
 }
 bool Node::HasProperty(const std::string& name) const {
-  static auto predicate = [name](const Property& property) { return property.name == name; };
-  return std::find_if(properties.begin(), properties.end(), predicate) != properties.end();
+  auto predicate = [name](const Property& property) { return property.name == name; };
+  return std::any_of(properties.begin(), properties.end(), predicate);
 }
 unsigned Node::PropertyCount() const {
   return properties.size();

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -4,33 +4,13 @@ namespace scc::translator::cypher {
 
 using std::format;
 
-Node::Label::Label(std::string name)
-    : value(std::move(name)) {}
-
-std::string Node::Label::ToString() const {
-  return ":" + value;
-}
-
-bool operator==(const Node::Label& lhs, const  Node::Label& rhs)  {
-  return lhs.value == rhs.value;
-}
-std::ostream& operator<<(std::ostream& os, const Node::Label& label) {
-  os << label.ToString();
-  return os;
-}
-bool operator<(const Node::Label& lhs, const Node::Label& rhs) {
-  return lhs.value < rhs.value;
-}
-
-Node::Node(std::string label_name)
-    : labels({Label(std::move(label_name))}) {}
-Node::Node(std::string label_name, std::string variable)
-    : labels({Label(std::move(label_name))}), variable(std::move(variable)) {}
-Node::Node(Label label)
+Node::Node(std::string label)
     : labels({std::move(label)}) {}
-Node::Node(Label label, std::vector<Property> properties)
+Node::Node(std::string label_name, std::string variable)
+    : labels({std::move(label_name)}), variable(std::move(variable)) {}
+Node::Node(std::string label, std::vector<Property> properties)
     : labels({std::move(label)}), properties(std::move(properties)) {}
-Node::Node(Label label, std::vector<Property> properties, std::string variable)
+Node::Node(std::string label, std::vector<Property> properties, std::string variable)
     : labels({std::move(label)}), properties(std::move(properties)),
       variable(std::move(variable)) {}
 
@@ -53,14 +33,6 @@ bool Node::HasProperty(const std::string& name) const {
 unsigned Node::PropertyCount() const {
   return properties.size();
 }
-Node& Node::AddLabel(const Label& label) {
-  labels.insert(label);
-  return *this;
-}
-Node& Node::AddLabel(const std::string& label) {
-  labels.insert(Label(label));
-  return *this;
-}
 Node& Node::SetVariable(const std::string& variable) {
   this->variable = variable;
   return *this;
@@ -73,7 +45,7 @@ std::string Node::ToString() const {
     ss << variable;
   }
   for (const auto& label : labels) {
-    ss << label.ToString();
+    ss << ":" << label;
   }
   if (!properties.empty()) {
     ss << " {";

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -5,14 +5,13 @@ namespace scc::translator::cypher {
 using std::format;
 
 Node::Node(std::string label)
-    : label(std::move(label)) {}
+    : BaseNode::BaseNode(std::move(label), {}) {}
 Node::Node(std::string label, std::string variable)
-    : label(std::move(label)), variable(std::move(variable)) {}
+    : BaseNode::BaseNode(std::move(label), {}), variable(std::move(variable)) {}
 Node::Node(std::string label, std::vector<Property> properties)
-    : label(std::move(label)), properties(std::move(properties)) {}
+    : BaseNode::BaseNode(std::move(label), std::move(properties)) {}
 Node::Node(std::string label, std::vector<Property> properties, std::string variable)
-    : label(std::move(label)), properties(std::move(properties)),
-      variable(std::move(variable)) {}
+    : BaseNode::BaseNode(std::move(label), std::move(properties)), variable(std::move(variable)) {}
 
 Node& Node::AddProperty(const Property& property) {
   if (HasProperty(property.name)) {

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -2,6 +2,8 @@
 
 namespace scc::translator::cypher {
 
+using std::format;
+
 Node::Label::Label(std::string name)
     : value(std::move(name)) {}
 
@@ -9,6 +11,9 @@ std::string Node::Label::ToString() const {
   return ":" + value;
 }
 
+bool operator==(const Node::Label& lhs, const  Node::Label& rhs)  {
+  return lhs.value == rhs.value;
+}
 std::ostream& operator<<(std::ostream& os, const Node::Label& label) {
   os << label.ToString();
   return os;
@@ -30,6 +35,10 @@ Node::Node(Label label, std::vector<Property> properties, std::string variable)
       variable(std::move(variable)) {}
 
 Node& Node::AddProperty(const Property& property) {
+  if (HasProperty(property.name)) {
+    std::string msg = format("Property {} already exists", property.ToString());
+    throw std::runtime_error(msg);
+  }
   properties.push_back(property);
   return *this;
 }
@@ -45,11 +54,11 @@ unsigned Node::PropertyCount() const {
   return properties.size();
 }
 Node& Node::AddLabel(const Label& label) {
-  labels.push_back(label);
+  labels.insert(label);
   return *this;
 }
 Node& Node::AddLabel(const std::string& label) {
-  labels.emplace_back(label);
+  labels.insert(Label(label));
   return *this;
 }
 Node& Node::SetVariable(const std::string& variable) {
@@ -80,6 +89,17 @@ std::string Node::ToString() const {
   return ss.str();
 }
 
+bool operator==(const Node& lhs, const Node& rhs)  {
+  if (lhs.labels != rhs.labels) {
+    return false;
+  }
+
+  if (lhs.properties != rhs.properties) {
+    return false;
+  }
+
+  return true;
+}
 std::ostream& operator<<(std::ostream& os, const Node& node) {
   os << node.ToString();
   return os;

--- a/src/translator/cypher/graph/node.cpp
+++ b/src/translator/cypher/graph/node.cpp
@@ -5,26 +5,26 @@ namespace scc::translator::cypher {
 using std::format;
 
 Node::Node(std::string label)
-    : labels({std::move(label)}) {}
-Node::Node(std::string label_name, std::string variable)
-    : labels({std::move(label_name)}), variable(std::move(variable)) {}
+    : label(std::move(label)) {}
+Node::Node(std::string label, std::string variable)
+    : label(std::move(label)), variable(std::move(variable)) {}
 Node::Node(std::string label, std::vector<Property> properties)
-    : labels({std::move(label)}), properties(std::move(properties)) {}
+    : label(std::move(label)), properties(std::move(properties)) {}
 Node::Node(std::string label, std::vector<Property> properties, std::string variable)
-    : labels({std::move(label)}), properties(std::move(properties)),
+    : label(std::move(label)), properties(std::move(properties)),
       variable(std::move(variable)) {}
 
 Node& Node::AddProperty(const Property& property) {
   if (HasProperty(property.name)) {
-    std::string msg = format("Property {} already exists", property.ToString());
+    std::string msg = format(R"(Property with name '{}' already exists in node '{}')",
+                             property.name, label);
     throw std::runtime_error(msg);
   }
   properties.push_back(property);
   return *this;
 }
 Node& Node::AddProperty(const std::string& name, const std::string& value, PropertyType type) {
-  properties.emplace_back(name, value, type);
-  return *this;
+  return AddProperty(Property(name, value, type));
 }
 bool Node::HasProperty(const std::string& name) const {
   auto predicate = [name](const Property& property) { return property.name == name; };
@@ -44,9 +44,7 @@ std::string Node::ToString() const {
   if (!variable.empty()) {
     ss << variable;
   }
-  for (const auto& label : labels) {
-    ss << ":" << label;
-  }
+  ss << ":" << label;
   if (!properties.empty()) {
     ss << " {";
     for (auto it = properties.begin(); it != properties.end(); ++it) {
@@ -62,7 +60,7 @@ std::string Node::ToString() const {
 }
 
 bool operator==(const Node& lhs, const Node& rhs)  {
-  if (lhs.labels != rhs.labels) {
+  if (lhs.label != rhs.label) {
     return false;
   }
 

--- a/src/translator/cypher/graph/property.cpp
+++ b/src/translator/cypher/graph/property.cpp
@@ -4,6 +4,30 @@ namespace scc::translator::cypher {
 
 Property::Property(std::string  name, std::string value, PropertyType type)
     : name(std::move(name)), value(std::move(value)), type(type) {}
+Property::Property(std::string name, std::string value, PropertyType type,
+                   std::vector<ConstraintType> constraints)
+    : name(std::move(name)), value(std::move(value)), type(type),
+      constraints(std::move(constraints)) {}
+
+void Property::AddConstraint(ConstraintType constraint) {
+  if (std::find(constraints.begin(), constraints.end(), constraint) == constraints.end()) {
+    constraints.push_back(constraint);
+  }
+}
+void Property::RemoveConstraint(ConstraintType constraint) {
+  auto it = std::find(constraints.begin(), constraints.end(), constraint);
+  if (it != constraints.end()) {
+    constraints.erase(it);
+  }
+}
+bool Property::MustBeUnique() const {
+  return std::any_of(constraints.begin(), constraints.end(),
+                     [](ConstraintType c) { return c == ConstraintType::kUniqueness; });
+}
+bool Property::MustBeNotNull() const {
+  return std::any_of(constraints.begin(), constraints.end(),
+                     [](ConstraintType c) { return c == ConstraintType::kExistence; });
+}
 
 std::string Property::ToString() const {
   return name + ": " + value;

--- a/src/translator/cypher/graph/property.cpp
+++ b/src/translator/cypher/graph/property.cpp
@@ -1,0 +1,23 @@
+#include "SCC/translator/cypher/graph/property.h"
+
+namespace scc::translator::cypher {
+
+Property::Property(std::string  name, std::string value, PropertyType type)
+    : name(std::move(name)), value(std::move(value)), type(type) {}
+
+std::string Property::ToString() const {
+  return name + ": " + value;
+}
+
+std::ostream& operator<<(std::ostream& os, const Property &property) {
+  os << property.ToString();
+  return os;
+}
+bool operator<(const Property& lhs, const Property& rhs) {
+  if (lhs.type != rhs.type) {
+    return lhs.type < rhs.type;
+  }
+  return lhs.name < rhs.name;
+}
+
+} // scc::translator::cypher

--- a/src/translator/cypher/graph/property.cpp
+++ b/src/translator/cypher/graph/property.cpp
@@ -3,7 +3,7 @@
 namespace scc::translator::cypher {
 
 Property::Property(std::string  name, std::string value, PropertyType type)
-    : BaseProperty::BaseProperty(std::move(name), type), value(std::move(value)) {}
+    : name(std::move(name)), type(type), value(std::move(value)) {}
 
 std::string Property::ToString() const {
   return name + ": " + value;

--- a/src/translator/cypher/graph/property.cpp
+++ b/src/translator/cypher/graph/property.cpp
@@ -4,30 +4,6 @@ namespace scc::translator::cypher {
 
 Property::Property(std::string  name, std::string value, PropertyType type)
     : BaseProperty::BaseProperty(std::move(name), type), value(std::move(value)) {}
-Property::Property(std::string name, std::string value, PropertyType type,
-                   std::vector<ConstraintType> constraints)
-    : BaseProperty::BaseProperty(std::move(name), type), value(std::move(value)),
-      constraints(std::move(constraints)) {}
-
-void Property::AddConstraint(ConstraintType constraint) {
-  if (std::find(constraints.begin(), constraints.end(), constraint) == constraints.end()) {
-    constraints.push_back(constraint);
-  }
-}
-void Property::RemoveConstraint(ConstraintType constraint) {
-  auto it = std::find(constraints.begin(), constraints.end(), constraint);
-  if (it != constraints.end()) {
-    constraints.erase(it);
-  }
-}
-bool Property::MustBeUnique() const {
-  return std::any_of(constraints.begin(), constraints.end(),
-                     [](ConstraintType c) { return c == ConstraintType::kUniqueness; });
-}
-bool Property::MustBeNotNull() const {
-  return std::any_of(constraints.begin(), constraints.end(),
-                     [](ConstraintType c) { return c == ConstraintType::kExistence; });
-}
 
 std::string Property::ToString() const {
   return name + ": " + value;
@@ -37,6 +13,9 @@ bool operator==(const Property& lhs, const Property& rhs) {
   return lhs.name == rhs.name
       && lhs.value == rhs.value
       && lhs.type == rhs.type;
+}
+bool operator!=(const Property& lhs, const Property& rhs) {
+  return !(lhs == rhs);
 }
 std::ostream& operator<<(std::ostream& os, const Property &property) {
   os << property.ToString();

--- a/src/translator/cypher/graph/property.cpp
+++ b/src/translator/cypher/graph/property.cpp
@@ -3,10 +3,10 @@
 namespace scc::translator::cypher {
 
 Property::Property(std::string  name, std::string value, PropertyType type)
-    : name(std::move(name)), value(std::move(value)), type(type) {}
+    : BaseProperty::BaseProperty(std::move(name), type), value(std::move(value)) {}
 Property::Property(std::string name, std::string value, PropertyType type,
                    std::vector<ConstraintType> constraints)
-    : name(std::move(name)), value(std::move(value)), type(type),
+    : BaseProperty::BaseProperty(std::move(name), type), value(std::move(value)),
       constraints(std::move(constraints)) {}
 
 void Property::AddConstraint(ConstraintType constraint) {

--- a/src/translator/cypher/graph/property.cpp
+++ b/src/translator/cypher/graph/property.cpp
@@ -33,6 +33,11 @@ std::string Property::ToString() const {
   return name + ": " + value;
 }
 
+bool operator==(const Property& lhs, const Property& rhs) {
+  return lhs.name == rhs.name
+      && lhs.value == rhs.value
+      && lhs.type == rhs.type;
+}
 std::ostream& operator<<(std::ostream& os, const Property &property) {
   os << property.ToString();
   return os;

--- a/src/translator/cypher/graph/relationship.cpp
+++ b/src/translator/cypher/graph/relationship.cpp
@@ -45,6 +45,20 @@ std::string Relationship::GetRightArrow() const {
   return "-";
 }
 
+bool operator==(const Relationship& lhs, const Relationship& rhs) {
+  if (lhs.properties != rhs.properties) {
+    return false;
+  }
+
+  if (lhs.type != rhs.type
+      || lhs.start != rhs.start
+      || lhs.end != rhs.end
+      || lhs.direction != rhs.direction) {
+    return false;
+  }
+
+  return true;
+}
 std::ostream& operator<<(std::ostream& os, const Relationship& relationship) {
   os << relationship.ToString();
   return os;

--- a/src/translator/cypher/graph/relationship.cpp
+++ b/src/translator/cypher/graph/relationship.cpp
@@ -15,7 +15,19 @@ std::string Relationship::ToString() const {
   std::stringstream ss;
   ss << (start.variable.empty() ? start.ToString() : "(" + start.variable + ")");
   ss << GetLeftArrow();
-  ss << "[" << variable << ":" << type << "]";
+  ss << "[";
+  ss << variable << ":" << type;
+  if (!properties.empty()) {
+    ss << " {";
+    for (auto it = properties.begin(); it != properties.end(); ++it) {
+      if (it != properties.begin()) {
+        ss << ", ";
+      }
+      ss << it->ToString();
+    }
+    ss << "}";
+  }
+  ss << "]";
   ss << GetRightArrow();
   ss << (end.variable.empty() ? end.ToString() : "(" + end.variable + ")");
 

--- a/src/translator/cypher/graph/relationship.cpp
+++ b/src/translator/cypher/graph/relationship.cpp
@@ -1,21 +1,17 @@
-#include <utility>
-
 #include "SCC/translator/cypher/graph/relationship.h"
 
 namespace scc::translator::cypher {
 
 Relationship::Relationship(std::string type, Node start, Node end, Direction direction)
-    : BaseRelationship::BaseRelationship(std::move(type)), start(std::move(start)),
-      end(std::move(end)), direction(direction) {}
+    : type(std::move(type)), start(std::move(start)), end(std::move(end)), direction(direction) {}
 Relationship::Relationship(std::string type, Node start, Node end, std::string variable,
                            Direction direction)
-    : BaseRelationship::BaseRelationship(std::move(type)), start(std::move(start)),
-      end(std::move(end)), direction(direction), variable(std::move(variable)) {}
+    : type(std::move(type)), start(std::move(start)), end(std::move(end)), direction(direction),
+      variable(std::move(variable)) {}
 Relationship::Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
                            std::string variable, Direction direction)
-    : BaseRelationship::BaseRelationship(std::move(type)), start(std::move(start)),
-      end(std::move(end)), direction(direction), properties(std::move(properties)),
-      variable(std::move(variable)) {}
+    : type(std::move(type)), start(std::move(start)), end(std::move(end)), direction(direction),
+      properties(std::move(properties)), variable(std::move(variable)) {}
 
 std::string Relationship::ToString() const {
   std::stringstream ss;

--- a/src/translator/cypher/graph/relationship.cpp
+++ b/src/translator/cypher/graph/relationship.cpp
@@ -5,15 +5,17 @@
 namespace scc::translator::cypher {
 
 Relationship::Relationship(std::string type, Node start, Node end, Direction direction)
-    : type(std::move(type)), start(std::move(start)), end(std::move(end)), direction(direction) {}
+    : BaseRelationship::BaseRelationship(std::move(type), std::move(start), std::move(end), {}),
+      direction(direction) {}
 Relationship::Relationship(std::string type, Node start, Node end, std::string variable,
                            Direction direction)
-    : type(std::move(type)), start(std::move(start)), end(std::move(end)), direction(direction),
-      variable(std::move(variable)) {}
+    : BaseRelationship::BaseRelationship(std::move(type), std::move(start), std::move(end), {}),
+      direction(direction), variable(std::move(variable)) {}
 Relationship::Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
                            std::string variable, Direction direction)
-    : type(std::move(type)), start(std::move(start)), end(std::move(end)), direction(direction),
-      properties(std::move(properties)), variable(std::move(variable)) {}
+    : BaseRelationship::BaseRelationship(std::move(type), std::move(start), std::move(end),
+                                         std::move(properties)),
+      direction(direction), variable(std::move(variable)) {}
 
 std::string Relationship::ToString() const {
   std::stringstream ss;

--- a/src/translator/cypher/graph/relationship.cpp
+++ b/src/translator/cypher/graph/relationship.cpp
@@ -5,17 +5,17 @@
 namespace scc::translator::cypher {
 
 Relationship::Relationship(std::string type, Node start, Node end, Direction direction)
-    : BaseRelationship::BaseRelationship(std::move(type), std::move(start), std::move(end), {}),
-      direction(direction) {}
+    : BaseRelationship::BaseRelationship(std::move(type)), start(std::move(start)),
+      end(std::move(end)), direction(direction) {}
 Relationship::Relationship(std::string type, Node start, Node end, std::string variable,
                            Direction direction)
-    : BaseRelationship::BaseRelationship(std::move(type), std::move(start), std::move(end), {}),
-      direction(direction), variable(std::move(variable)) {}
+    : BaseRelationship::BaseRelationship(std::move(type)), start(std::move(start)),
+      end(std::move(end)), direction(direction), variable(std::move(variable)) {}
 Relationship::Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
                            std::string variable, Direction direction)
-    : BaseRelationship::BaseRelationship(std::move(type), std::move(start), std::move(end),
-                                         std::move(properties)),
-      direction(direction), variable(std::move(variable)) {}
+    : BaseRelationship::BaseRelationship(std::move(type)), start(std::move(start)),
+      end(std::move(end)), direction(direction), properties(std::move(properties)),
+      variable(std::move(variable)) {}
 
 std::string Relationship::ToString() const {
   std::stringstream ss;
@@ -52,14 +52,14 @@ std::string Relationship::GetRightArrow() const {
 }
 
 bool operator==(const Relationship& lhs, const Relationship& rhs) {
-  if (lhs.properties != rhs.properties) {
-    return false;
-  }
-
   if (lhs.type != rhs.type
       || lhs.start != rhs.start
       || lhs.end != rhs.end
       || lhs.direction != rhs.direction) {
+    return false;
+  }
+
+  if (lhs.properties != rhs.properties) {
     return false;
   }
 
@@ -69,12 +69,5 @@ std::ostream& operator<<(std::ostream& os, const Relationship& relationship) {
   os << relationship.ToString();
   return os;
 }
-
-ConditionalRelationship::ConditionalRelationship(const Relationship& relationship,
-                                                 std::vector<ApplyCondition> conditions)
-    : Relationship::Relationship(relationship.type, relationship.start, relationship.end,
-                                 relationship.properties, relationship.variable,
-                                 relationship.direction),
-      conditions(std::move(conditions)) {}
 
 } // scc::translator::cypher

--- a/src/translator/cypher/graph/relationship.cpp
+++ b/src/translator/cypher/graph/relationship.cpp
@@ -10,6 +10,10 @@ Relationship::Relationship(std::string type, Node start, Node end, std::string v
                            Direction direction)
     : type(std::move(type)), start(std::move(start)), end(std::move(end)), direction(direction),
       variable(std::move(variable)) {}
+Relationship::Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
+                           std::string variable, Direction direction)
+    : type(std::move(type)), start(std::move(start)), end(std::move(end)), direction(direction),
+      properties(std::move(properties)), variable(std::move(variable)) {}
 
 std::string Relationship::ToString() const {
   std::stringstream ss;
@@ -63,5 +67,12 @@ std::ostream& operator<<(std::ostream& os, const Relationship& relationship) {
   os << relationship.ToString();
   return os;
 }
+
+ConditionalRelationship::ConditionalRelationship(const Relationship& relationship,
+                                                 std::vector<ApplyCondition> conditions)
+    : Relationship::Relationship(relationship.type, relationship.start, relationship.end,
+                                 relationship.properties, relationship.variable,
+                                 relationship.direction),
+      conditions(std::move(conditions)) {}
 
 } // scc::translator::cypher

--- a/src/translator/cypher/schema.cpp
+++ b/src/translator/cypher/schema.cpp
@@ -4,4 +4,23 @@ namespace scc::translator::cypher {
 
 Schema::Schema(std::string database_name) : database_name(std::move(database_name)) {}
 
+void Schema::AddNode(const Node& node) {
+  auto it = std::find(nodes.begin(), nodes.end(), node);
+  if (it != nodes.end()) {
+    std::string msg = format(R"(Node '{}' already exists in schema for database '{}')",
+                             node.label, database_name);
+    throw std::runtime_error(msg);
+  }
+  nodes.push_back(node);
+}
+void Schema::AddConditionalRelationship(const ConditionalRelationship& relationship) {
+  auto it = std::find(relationships.begin(), relationships.end(), relationship);
+  if (it != relationships.end()) {
+    std::string msg = format(R"(Relationship '{}' already exists in schema for database '{}')",
+                             relationship.type, database_name);
+    throw std::runtime_error(msg);
+  }
+  relationships.push_back(relationship);
+}
+
 } // scc::translator::cypher

--- a/src/translator/cypher/schema.cpp
+++ b/src/translator/cypher/schema.cpp
@@ -1,0 +1,7 @@
+#include "SCC/translator/cypher/schema.h"
+
+namespace scc::translator::cypher {
+
+Schema::Schema(std::string database_name) : database_name(std::move(database_name)) {}
+
+} // scc::translator::cypher

--- a/src/translator/ddl/ddl_statements.cpp
+++ b/src/translator/ddl/ddl_statements.cpp
@@ -55,7 +55,7 @@ void Translator::TranslateCreateTableStatement(const NodePtr<INode>& stmt) {
   ValidateHasChildren(table_definition, 1, "Empty table definition" + msg_suffix);
   auto table_definition_element = table_definition->Child(0);
   if (IsCorrectStmtType(table_definition_element, StmtType::kColumnDef)) {
-    std::vector<NodeProperty> properties = TranslateColumnDefinitions(table_definition);
+    std::vector<Property> properties = TranslateColumnDefinitions(table_definition);
     for (auto& property: properties) {
       node.AddProperty(property);
     }
@@ -119,7 +119,7 @@ void Translator::TranslateAlterTableActionAdd(const NodePtr<INode>& action_node,
   ValidateHasChildren(table_definition, 1, "Missing column definition or constraint" + msg_suffix);
   auto add_element = table_definition->Child(0);
   if (IsCorrectStmtType(add_element, StmtType::kColumnDef)) {
-    std::vector<NodeProperty> properties = TranslateColumnDefinitions(table_definition);
+    std::vector<Property> properties = TranslateColumnDefinitions(table_definition);
     for (auto& property: properties) {
       WriteCypherQuery(SetPropertyClauseBuilder::Build(node, property));
       node.AddProperty(property);
@@ -142,8 +142,8 @@ void Translator::TranslateAlterTableActionDrop(const NodePtr<INode>& action_node
   }
 }
 
-std::vector<NodeProperty> Translator::TranslateColumnDefinitions(const NodePtr<INode>& node) {
-  std::vector<NodeProperty> properties;
+std::vector<Property> Translator::TranslateColumnDefinitions(const NodePtr<INode>& node) {
+  std::vector<Property> properties;
 
   for (unsigned i = 0; HasChildren(node, i + 1); ++i) {
     auto column_definition = node->Child(i);
@@ -151,13 +151,13 @@ std::vector<NodeProperty> Translator::TranslateColumnDefinitions(const NodePtr<I
       break;
     }
     ValidateHasChildren(column_definition);
-    NodeProperty property = TranslateColumnDefinition(column_definition);
+    Property property = TranslateColumnDefinition(column_definition);
     properties.push_back(property);
   }
 
   return properties;
 }
-NodeProperty Translator::TranslateColumnDefinition(const NodePtr<INode>& node) {
+Property Translator::TranslateColumnDefinition(const NodePtr<INode>& node) {
   auto column_name_node = node->Child(0);
   ValidateHasChildren(column_name_node);
   std::string column_name = GetName(column_name_node);
@@ -185,7 +185,7 @@ NodeProperty Translator::TranslateColumnDefinition(const NodePtr<INode>& node) {
       throw translation_error(format("Unknown SQL datatype \'{}\'", datatype.ToString()));
   }
 
-  return NodeProperty(column_name, datatype_str, property_type);
+  return Property(column_name, datatype_str, property_type);
 }
 void Translator::TranslateTableConstraint(const NodePtr<INode>& constraint_definition,
                                           const std::string& table_name) {

--- a/src/translator/ddl/ddl_statements.cpp
+++ b/src/translator/ddl/ddl_statements.cpp
@@ -60,7 +60,7 @@ void Translator::TranslateCreateTableStatement(const ASTNodePtr<INode>& stmt) {
       node.AddProperty(property);
     }
   }
-  WriteCypherQuery(CreateNodeClauseBuilder::Build(node));
+  schema_.AddNode(node);
 
   for (unsigned i = node.PropertyCount(); HasChildren(table_definition, i + 1); ++i) {
     auto constraint_definition = table_definition->Child(i);
@@ -95,7 +95,7 @@ void Translator::TranslateDropDatabaseStatement(const ASTNodePtr<INode>& stmt) {
     ValidateHasChildren(database_name_node);
     auto database_name = GetName(database_name_node);
 
-    WriteCypherQuery(DropDatabaseClauseBuilder::Build(database_name));
+    schema_.Clear();
   }
 }
 void Translator::TranslateDropTableStatement(const ASTNodePtr<INode>& stmt) {
@@ -103,9 +103,7 @@ void Translator::TranslateDropTableStatement(const ASTNodePtr<INode>& stmt) {
     auto table_name_node = stmt->Child(i);
     ValidateHasChildren(table_name_node);
     auto table_name = GetName(table_name_node);
-
-    Node node(table_name);
-    WriteCypherQuery(DeleteNodeClauseBuilder::Build(node));
+    schema_.RemoveNode(table_name);
   }
 }
 
@@ -115,18 +113,18 @@ void Translator::TranslateAlterTableActionAdd(const ASTNodePtr<INode>& action_no
 
   auto table_definition = action_node->Child(0);
 
-  Node node(table_name, "n");
   ValidateHasChildren(table_definition, 1, "Missing column definition or constraint" + msg_suffix);
   auto add_element = table_definition->Child(0);
+  unsigned added_columns = 0;
   if (IsCorrectStmtType(add_element, StmtType::kColumnDef)) {
     std::vector<Property> properties = TranslateColumnDefinitions(table_definition);
     for (auto& property: properties) {
-      WriteCypherQuery(SetPropertyClauseBuilder::Build(node, property));
-      node.AddProperty(property);
+      schema_.AddNodeProperty(table_name, property);
     }
+    added_columns = properties.size();
   }
 
-  for (unsigned i = node.PropertyCount(); HasChildren(table_definition, i + 1); ++i) {
+  for (unsigned i = added_columns; HasChildren(table_definition, i + 1); ++i) {
     auto constraint_definition = table_definition->Child(i);
     TranslateTableConstraint(constraint_definition, table_name);
   }
@@ -165,20 +163,16 @@ Property Translator::TranslateColumnDefinition(const ASTNodePtr<INode>& node) {
   ValidateHasChildren(node, 2, "Missing datatype in column definition");
   StmtType datatype = node->Child(1)->stmt_type;
 
-  std::string datatype_str;
   PropertyType property_type;
   switch (datatype) {
     case StmtType::kIntType:
-      datatype_str = "0";
       property_type = PropertyType::kInteger;
       break;
     case StmtType::kFloatType:
-      datatype_str = "0.0";
       property_type = PropertyType::kFloat;
       break;
     case StmtType::kCharType:
     case StmtType::kVarcharType:
-      datatype_str = "\"\"";
       property_type = PropertyType::kString;
       break;
     default:
@@ -229,12 +223,14 @@ void Translator::TranslateDropElement(const ASTNodePtr<INode>& node, std::string
   switch (node->stmt_type) {
     case StmtType::kDropColumn:
       for (const auto& arg: arguments) {
-        RemoveProperty(table_name, arg);
+        schema_.RemoveNodeProperty(table_name, arg);
       }
       break;
     case StmtType::kDropConstraint:
       for (const auto& arg: arguments) {
-        WriteCypherQuery(DropConstraintClauseBuilder::Build(arg));
+        // TODO: return bool to indicate success and do not find relationship to remove.
+        schema_.RemoveNodePropertyConstraints(table_name, arg);
+        schema_.RemoveRelationship(arg);
       }
       break;
     default:

--- a/src/translator/ddl/ddl_statements.cpp
+++ b/src/translator/ddl/ddl_statements.cpp
@@ -3,15 +3,17 @@
 namespace scc::translator {
 
 using namespace ast;
-using namespace cypher;
+using namespace schema;
+
+using cypher::PropertyType;
 
 using std::format;
 
-template<typename NodeType,
-    typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
-using NodePtr = std::shared_ptr<NodeType>;
+template<typename ASTNodeType,
+    typename std::enable_if<std::is_base_of<INode, ASTNodeType>::value>::type* = nullptr>
+using ASTNodePtr = std::shared_ptr<ASTNodeType>;
 
-void Translator::TranslateDDLStatement(const NodePtr<INode>& ddl_statement) {
+void Translator::TranslateDDLStatement(const ASTNodePtr<INode>& ddl_statement) {
   switch (ddl_statement->stmt_type) {
     case StmtType::kCreateDatabaseStmt:
       TranslateCreateDatabaseStatement(ddl_statement);
@@ -34,14 +36,12 @@ void Translator::TranslateDDLStatement(const NodePtr<INode>& ddl_statement) {
   }
 }
 
-void Translator::TranslateCreateDatabaseStatement(const NodePtr<INode>& stmt) {
+void Translator::TranslateCreateDatabaseStatement(const ASTNodePtr<INode>& stmt) {
   auto database_name_node = stmt->Child(0);
   ValidateHasChildren(database_name_node);
-  std::string database_name = GetName(database_name_node);
-
-  WriteCypherQuery(CreateDatabaseClauseBuilder::Build(database_name));
+  schema_.database_name = GetName(database_name_node);
 }
-void Translator::TranslateCreateTableStatement(const NodePtr<INode>& stmt) {
+void Translator::TranslateCreateTableStatement(const ASTNodePtr<INode>& stmt) {
   const std::string msg_suffix = " in \'CREATE TABLE\' statement";
 
   auto table_name_node = stmt->Child(0);
@@ -67,7 +67,7 @@ void Translator::TranslateCreateTableStatement(const NodePtr<INode>& stmt) {
     TranslateTableConstraint(constraint_definition, table_name);
   }
 }
-void Translator::TranslateAlterTableStatement(const NodePtr<INode>& stmt) {
+void Translator::TranslateAlterTableStatement(const ASTNodePtr<INode>& stmt) {
   const std::string msg_suffix = " in \'ALTER TABLE\' statement";
 
   auto table_name_node = stmt->Child(0);
@@ -89,7 +89,7 @@ void Translator::TranslateAlterTableStatement(const NodePtr<INode>& stmt) {
                                      action_node->stmt_type.ToString(), msg_suffix));
   }
 }
-void Translator::TranslateDropDatabaseStatement(const NodePtr<INode>& stmt) {
+void Translator::TranslateDropDatabaseStatement(const ASTNodePtr<INode>& stmt) {
   for (unsigned i = 0; HasChildren(stmt, i + 1); ++i) {
     auto database_name_node = stmt->Child(i);
     ValidateHasChildren(database_name_node);
@@ -98,7 +98,7 @@ void Translator::TranslateDropDatabaseStatement(const NodePtr<INode>& stmt) {
     WriteCypherQuery(DropDatabaseClauseBuilder::Build(database_name));
   }
 }
-void Translator::TranslateDropTableStatement(const NodePtr<INode>& stmt) {
+void Translator::TranslateDropTableStatement(const ASTNodePtr<INode>& stmt) {
   for (unsigned i = 0; HasChildren(stmt, i + 1); ++i) {
     auto table_name_node = stmt->Child(i);
     ValidateHasChildren(table_name_node);
@@ -109,7 +109,7 @@ void Translator::TranslateDropTableStatement(const NodePtr<INode>& stmt) {
   }
 }
 
-void Translator::TranslateAlterTableActionAdd(const NodePtr<INode>& action_node,
+void Translator::TranslateAlterTableActionAdd(const ASTNodePtr<INode>& action_node,
                                               std::string& table_name) {
   const std::string msg_suffix = " in \'ALTER TABLE ADD\' statement";
 
@@ -131,7 +131,7 @@ void Translator::TranslateAlterTableActionAdd(const NodePtr<INode>& action_node,
     TranslateTableConstraint(constraint_definition, table_name);
   }
 }
-void Translator::TranslateAlterTableActionDrop(const NodePtr<INode>& action_node,
+void Translator::TranslateAlterTableActionDrop(const ASTNodePtr<INode>& action_node,
                                                std::string& table_name) {
   auto alter_drop_list = action_node->Child(0);
   ValidateHasChildren(alter_drop_list, 1, "Missing arguments in \'ALTER TABLE DROP\' statement");
@@ -142,7 +142,7 @@ void Translator::TranslateAlterTableActionDrop(const NodePtr<INode>& action_node
   }
 }
 
-std::vector<Property> Translator::TranslateColumnDefinitions(const NodePtr<INode>& node) {
+std::vector<Property> Translator::TranslateColumnDefinitions(const ASTNodePtr<INode>& node) {
   std::vector<Property> properties;
 
   for (unsigned i = 0; HasChildren(node, i + 1); ++i) {
@@ -157,7 +157,7 @@ std::vector<Property> Translator::TranslateColumnDefinitions(const NodePtr<INode
 
   return properties;
 }
-Property Translator::TranslateColumnDefinition(const NodePtr<INode>& node) {
+Property Translator::TranslateColumnDefinition(const ASTNodePtr<INode>& node) {
   auto column_name_node = node->Child(0);
   ValidateHasChildren(column_name_node);
   std::string column_name = GetName(column_name_node);
@@ -185,9 +185,9 @@ Property Translator::TranslateColumnDefinition(const NodePtr<INode>& node) {
       throw translation_error(format("Unknown SQL datatype \'{}\'", datatype.ToString()));
   }
 
-  return Property(column_name, datatype_str, property_type);
+  return Property(column_name, property_type);
 }
-void Translator::TranslateTableConstraint(const NodePtr<INode>& constraint_definition,
+void Translator::TranslateTableConstraint(const ASTNodePtr<INode>& constraint_definition,
                                           const std::string& table_name) {
   ValidateHasChildren(constraint_definition, 1, "Missing constraint definition");
 
@@ -217,7 +217,7 @@ void Translator::TranslateTableConstraint(const NodePtr<INode>& constraint_defin
   }
 }
 
-void Translator::TranslateDropElement(const NodePtr<INode>& node, std::string& table_name) {
+void Translator::TranslateDropElement(const ASTNodePtr<INode>& node, std::string& table_name) {
   std::vector<std::string> arguments;
   for (unsigned i = 0; HasChildren(node, i + 1); ++i) {
     auto argument_node = node->Child(i);

--- a/src/translator/schema/CMakeLists.txt
+++ b/src/translator/schema/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(scc_translator_schema STATIC)
+target_sources(scc_translator_schema PRIVATE
+        node.cpp
+        property.cpp
+        relationship.cpp
+        schema.cpp
+)
+target_link_libraries(scc_translator_schema PRIVATE
+        scc_include
+        scc_translator_cypher_graph
+)

--- a/src/translator/schema/node.cpp
+++ b/src/translator/schema/node.cpp
@@ -1,0 +1,41 @@
+#include "SCC/translator/schema/node.h"
+
+namespace scc::translator::schema {
+
+using cypher::BaseNode;
+
+Node::Node(std::string label)
+    : BaseNode::BaseNode(std::move(label)) {}
+Node::Node(std::string label, std::vector<Property> properties)
+    : BaseNode::BaseNode(std::move(label)), properties(std::move(properties)) {}
+
+Node& Node::AddProperty(const Property& property) {
+  if (HasProperty(property.name)) {
+    std::string msg = format(R"(Property with name '{}' already exists in node '{}')",
+                             property.name, label);
+    throw std::runtime_error(msg);
+  }
+  properties.push_back(property);
+  return *this;
+}
+bool Node::HasProperty(const std::string& name) const {
+  auto predicate = [name](const Property& property) { return property.name == name; };
+  return std::any_of(properties.begin(), properties.end(), predicate);
+}
+
+bool Node::operator==(const Node& other) const {
+  if (label != other.label) {
+    return false;
+  }
+
+  if (properties != other.properties) {
+    return false;
+  }
+
+  return true;
+}
+bool Node::operator!=(const Node& other) const {
+  return !(*this == other);
+}
+
+} // scc::translator::schema

--- a/src/translator/schema/node.cpp
+++ b/src/translator/schema/node.cpp
@@ -2,12 +2,12 @@
 
 namespace scc::translator::schema {
 
-using cypher::BaseNode;
+using std::format;
 
 Node::Node(std::string label)
-    : BaseNode::BaseNode(std::move(label)) {}
+    : label(std::move(label)) {}
 Node::Node(std::string label, std::vector<Property> properties)
-    : BaseNode::BaseNode(std::move(label)), properties(std::move(properties)) {}
+    : label(std::move(label)), properties(std::move(properties)) {}
 
 Node& Node::AddProperty(const Property& property) {
   if (HasProperty(property.name)) {

--- a/src/translator/schema/node.cpp
+++ b/src/translator/schema/node.cpp
@@ -22,6 +22,17 @@ bool Node::HasProperty(const std::string& name) const {
   auto predicate = [name](const Property& property) { return property.name == name; };
   return std::any_of(properties.begin(), properties.end(), predicate);
 }
+int Node::PropertyIndex(const std::string& name) const {
+  auto predicate = [name](const Property& property) { return property.name == name; };
+  auto it = std::find_if(properties.begin(), properties.end(), predicate);
+  if (it == properties.end()) {
+    return -1;
+  }
+  return std::distance(properties.begin(), it);
+}
+unsigned Node::PropertyCount() const {
+  return properties.size();
+}
 
 bool Node::operator==(const Node& other) const {
   if (label != other.label) {

--- a/src/translator/schema/property.cpp
+++ b/src/translator/schema/property.cpp
@@ -1,0 +1,42 @@
+#include "SCC/translator/schema/property.h"
+
+namespace scc::translator::schema {
+
+using cypher::ConstraintType;
+using cypher::PropertyType;
+
+Property::Property(std::string name, PropertyType type)
+    : BaseProperty::BaseProperty(std::move(name), type) {}
+Property::Property(std::string name, PropertyType type, std::vector<ConstraintType> constraints)
+    : BaseProperty::BaseProperty(std::move(name), type), constraints(std::move(constraints)) {}
+
+void Property::AddConstraint(ConstraintType constraint) {
+  if (std::find(constraints.begin(), constraints.end(), constraint) == constraints.end()) {
+    constraints.push_back(constraint);
+  }
+}
+void Property::RemoveConstraint(ConstraintType constraint) {
+  auto it = std::find(constraints.begin(), constraints.end(), constraint);
+  if (it != constraints.end()) {
+    constraints.erase(it);
+  }
+}
+bool Property::MustBeUnique() const {
+  return std::any_of(constraints.begin(), constraints.end(),
+                     [](ConstraintType c) { return c == ConstraintType::kUniqueness; });
+}
+bool Property::MustBeNotNull() const {
+  return std::any_of(constraints.begin(), constraints.end(),
+                     [](ConstraintType c) { return c == ConstraintType::kExistence; });
+}
+
+bool Property::operator==(const Property& other) const {
+  return name == other.name
+      && type == other.type
+      && constraints == other.constraints;
+}
+bool Property::operator!=(const Property& other) const {
+  return !(*this == other);
+}
+
+} // scc::translator::schema

--- a/src/translator/schema/property.cpp
+++ b/src/translator/schema/property.cpp
@@ -7,27 +7,25 @@ using cypher::PropertyType;
 
 Property::Property(std::string name, PropertyType type)
     : name(std::move(name)), type(type) {}
-Property::Property(std::string name, PropertyType type, std::vector<ConstraintType> constraints)
+Property::Property(std::string name, PropertyType type, std::vector<PropertyConstraint> constraints)
     : name(std::move(name)), type(type), constraints(std::move(constraints)) {}
 
-void Property::AddConstraint(ConstraintType constraint) {
-  if (std::find(constraints.begin(), constraints.end(), constraint) == constraints.end()) {
+void Property::AddConstraint(const PropertyConstraint& constraint) {
+  if (!HasConstraint(constraint)) {
     constraints.push_back(constraint);
   }
 }
-void Property::RemoveConstraint(ConstraintType constraint) {
+void Property::RemoveConstraint(const PropertyConstraint& constraint) {
   auto it = std::find(constraints.begin(), constraints.end(), constraint);
   if (it != constraints.end()) {
     constraints.erase(it);
   }
 }
 bool Property::MustBeUnique() const {
-  return std::any_of(constraints.begin(), constraints.end(),
-                     [](ConstraintType c) { return c == ConstraintType::kUniqueness; });
+  return HasConstraintType(ConstraintType::kUniqueness);
 }
 bool Property::MustBeNotNull() const {
-  return std::any_of(constraints.begin(), constraints.end(),
-                     [](ConstraintType c) { return c == ConstraintType::kExistence; });
+  return HasConstraintType(ConstraintType::kExistence);
 }
 
 bool Property::operator==(const Property& other) const {
@@ -37,6 +35,16 @@ bool Property::operator==(const Property& other) const {
 }
 bool Property::operator!=(const Property& other) const {
   return !(*this == other);
+}
+
+bool Property::HasConstraintType(ConstraintType constraint_type) const {
+  return std::any_of(constraints.begin(), constraints.end(),
+                     [constraint_type](const PropertyConstraint& c) {
+                       return c.type == constraint_type;
+                     });
+}
+bool Property::HasConstraint(const PropertyConstraint& constraint) const {
+  return std::find(constraints.begin(), constraints.end(), constraint) != constraints.end();
 }
 
 } // scc::translator::schema

--- a/src/translator/schema/property.cpp
+++ b/src/translator/schema/property.cpp
@@ -15,11 +15,11 @@ void Property::AddConstraint(const PropertyConstraint& constraint) {
     constraints.push_back(constraint);
   }
 }
-void Property::RemoveConstraint(const PropertyConstraint& constraint) {
-  auto it = std::find(constraints.begin(), constraints.end(), constraint);
-  if (it != constraints.end()) {
-    constraints.erase(it);
-  }
+void Property::RemoveConstraintsByPrefix(const std::string& prefix) {
+  std::remove_if(constraints.begin(), constraints.end(),
+                 [prefix](PropertyConstraint& constraint) {
+                   return constraint.name.starts_with(prefix);
+                 });
 }
 bool Property::MustBeUnique() const {
   return HasConstraintType(ConstraintType::kUniqueness);

--- a/src/translator/schema/property.cpp
+++ b/src/translator/schema/property.cpp
@@ -6,9 +6,9 @@ using cypher::ConstraintType;
 using cypher::PropertyType;
 
 Property::Property(std::string name, PropertyType type)
-    : BaseProperty::BaseProperty(std::move(name), type) {}
+    : name(std::move(name)), type(type) {}
 Property::Property(std::string name, PropertyType type, std::vector<ConstraintType> constraints)
-    : BaseProperty::BaseProperty(std::move(name), type), constraints(std::move(constraints)) {}
+    : name(std::move(name)), type(type), constraints(std::move(constraints)) {}
 
 void Property::AddConstraint(ConstraintType constraint) {
   if (std::find(constraints.begin(), constraints.end(), constraint) == constraints.end()) {

--- a/src/translator/schema/relationship.cpp
+++ b/src/translator/schema/relationship.cpp
@@ -2,16 +2,12 @@
 
 namespace scc::translator::schema {
 
-Relationship::Relationship(std::string type, Node start, Node end)
+Relationship::Relationship(std::string type, std::string start, std::string end)
     : type(std::move(type)), start(std::move(start)), end(std::move(end)) {}
-Relationship::Relationship(std::string type, Node start, Node end,
+Relationship::Relationship(std::string type, std::string start, std::string end,
                            std::vector<ApplyCondition> conditions)
     : type(std::move(type)), start(std::move(start)), end(std::move(end)),
       conditions(std::move(conditions)) {}
-Relationship::Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
-                           std::vector<ApplyCondition> conditions)
-    : type(std::move(type)), start(std::move(start)), end(std::move(end)),
-      properties(std::move(properties)), conditions(std::move(conditions)) {}
 
 Relationship& Relationship::AddCondition(ApplyCondition condition) {
   if (std::find(conditions.begin(), conditions.end(), condition) == conditions.end()) {
@@ -34,10 +30,6 @@ bool Relationship::operator==(const Relationship& other) const {
   if (type != other.type
       || start != other.start
       || end != other.end) {
-    return false;
-  }
-
-  if (properties != other.properties) {
     return false;
   }
   

--- a/src/translator/schema/relationship.cpp
+++ b/src/translator/schema/relationship.cpp
@@ -1,15 +1,11 @@
-#include <utility>
-
 #include "SCC/translator/schema/relationship.h"
 
 namespace scc::translator::schema {
 
-using cypher::BaseRelationship;
-
 Relationship::Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
                            std::vector<ApplyCondition> conditions)
-    : BaseRelationship::BaseRelationship(std::move(type)), start(std::move(start)),
-      end(std::move(end)), properties(std::move(properties)), conditions(std::move(conditions)) {}
+    : type(std::move(type)), start(std::move(start)), end(std::move(end)),
+      properties(std::move(properties)), conditions(std::move(conditions)) {}
 
 Relationship& Relationship::AddCondition(ApplyCondition condition) {
   if (std::find(conditions.begin(), conditions.end(), condition) == conditions.end()) {

--- a/src/translator/schema/relationship.cpp
+++ b/src/translator/schema/relationship.cpp
@@ -1,0 +1,42 @@
+#include <utility>
+
+#include "SCC/translator/schema/relationship.h"
+
+namespace scc::translator::schema {
+
+using cypher::BaseRelationship;
+
+Relationship::Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
+                           std::vector<ApplyCondition> conditions)
+    : BaseRelationship::BaseRelationship(std::move(type)), start(std::move(start)),
+      end(std::move(end)), properties(std::move(properties)), conditions(std::move(conditions)) {}
+
+Relationship& Relationship::AddCondition(ApplyCondition condition) {
+  if (std::find(conditions.begin(), conditions.end(), condition) == conditions.end()) {
+    conditions.push_back(condition);
+  }
+  return *this;
+}
+
+bool Relationship::operator==(const Relationship& other) const {
+  if (type != other.type
+      || start != other.start
+      || end != other.end) {
+    return false;
+  }
+
+  if (properties != other.properties) {
+    return false;
+  }
+  
+  if (conditions != other.conditions) {
+    return false;
+  }
+
+  return true;
+}
+bool Relationship::operator!=(const Relationship& other) const {
+  return !(*this == other);
+}
+
+} // scc::translator::schema

--- a/src/translator/schema/relationship.cpp
+++ b/src/translator/schema/relationship.cpp
@@ -2,6 +2,12 @@
 
 namespace scc::translator::schema {
 
+Relationship::Relationship(std::string type, Node start, Node end)
+    : type(std::move(type)), start(std::move(start)), end(std::move(end)) {}
+Relationship::Relationship(std::string type, Node start, Node end,
+                           std::vector<ApplyCondition> conditions)
+    : type(std::move(type)), start(std::move(start)), end(std::move(end)),
+      conditions(std::move(conditions)) {}
 Relationship::Relationship(std::string type, Node start, Node end, std::vector<Property> properties,
                            std::vector<ApplyCondition> conditions)
     : type(std::move(type)), start(std::move(start)), end(std::move(end)),
@@ -12,6 +18,16 @@ Relationship& Relationship::AddCondition(ApplyCondition condition) {
     conditions.push_back(condition);
   }
   return *this;
+}
+void Relationship::RemoveConditionBySPI(int spi) {
+  std::remove_if(conditions.begin(), conditions.end(), [spi](ApplyCondition& condition) {
+    return condition.spi == spi;
+  });
+}
+void Relationship::RemoveConditionByEPI(int epi) {
+  std::remove_if(conditions.begin(), conditions.end(), [epi](ApplyCondition& condition) {
+    return condition.epi == epi;
+  });
 }
 
 bool Relationship::operator==(const Relationship& other) const {

--- a/src/translator/schema/schema.cpp
+++ b/src/translator/schema/schema.cpp
@@ -2,33 +2,147 @@
 
 namespace scc::translator::schema {
 
+using std::format;
 using nlohmann::json;
+using cypher::ConstraintType;
+
+template<typename T>
+using RefWrapper = std::reference_wrapper<T>;
+using ConstNodeRefWrapper = RefWrapper<const Node>;
+using NodeRefWrapper = RefWrapper<Node>;
+template<typename T>
+using Optional = std::optional<T>;
 
 Schema::Schema(std::string database_name) : database_name(std::move(database_name)) {}
 
 void Schema::AddNode(const Node& node) {
   auto it = std::find(nodes.begin(), nodes.end(), node);
   if (it != nodes.end()) {
-    std::string msg = format(R"(Node '{}' already exists in schema for database '{}')",
-                             node.label, database_name);
+    std::string msg =
+        format(R"(Could not add new node: Node '{}' already exists in schema for database '{}')",
+               node.label, database_name);
     throw std::runtime_error(msg);
   }
   nodes.push_back(node);
 }
-void Schema::AddConditionalRelationship(const Relationship& relationship) {
+void Schema::AddNodeProperty(const std::string& label, const Property& property) {
+  auto& node = GetNodeOrThrow(label);
+  node.AddProperty(property);
+}
+void Schema::AddNodePropertyConstraint(const std::string& label, const std::string& property_name,
+                                       const PropertyConstraint& constraint) {
+  auto& node = GetNodeOrThrow(label);
+  auto& properties = node.properties;
+  auto propertyIt = std::find_if(properties.begin(), properties.end(),
+                                 [property_name](const Property& property) {
+                                   return property.name == property_name;
+                                 });
+  if (propertyIt == properties.end()) {
+    std::string msg = format("Could not add new property constraint: "
+                             "Property \'{}\' not found in node \'{}\' for database \'{}\'",
+                             property_name, label, database_name);
+    throw std::runtime_error(msg);
+  }
+
+  propertyIt->AddConstraint(constraint);
+}
+void Schema::AddRelationship(const Relationship& relationship) {
   auto it = std::find(relationships.begin(), relationships.end(), relationship);
   if (it != relationships.end()) {
-    std::string msg = format(R"(Relationship '{}' already exists in schema for database '{}')",
+    std::string msg = format("Could not add new relationship: "
+                             "Relationship \'{}\' already exists in schema for database \'{}\'",
                              relationship.type, database_name);
     throw std::runtime_error(msg);
   }
   relationships.push_back(relationship);
 }
 
-std::string Schema::ToJsonString(const int indent, const char indent_char) const {
+Optional<ConstNodeRefWrapper> Schema::FindNode(const std::string& label) const {
+  auto nodeIt = std::find_if(nodes.begin(), nodes.end(),
+                             [label](const Node& node) { return node.label == label; });
+  if (nodeIt == nodes.end()) {
+    return {};
+  }
+  return {ConstNodeRefWrapper(*nodeIt)};
+}
+const Node& Schema::FindNodeOrThrow(const std::string& label) const {
+  auto node_res = FindNode(label);
+  if (!node_res.has_value()) {
+    std::string msg = format(R"(Node '{}' not found in schema for database '{}')",
+                             label, database_name);
+    throw std::runtime_error(msg);
+  }
+  return node_res.value().get();
+}
+Optional<NodeRefWrapper> Schema::GetNode(const std::string& label) {
+  auto nodeIt = std::find_if(nodes.begin(), nodes.end(),
+                             [label](const Node& node) { return node.label == label; });
+  if (nodeIt == nodes.end()) {
+    return {};
+  }
+  return {NodeRefWrapper(*nodeIt)};
+}
+Node& Schema::GetNodeOrThrow(const std::string& label) {
+  auto node_res = GetNode(label);
+  if (!node_res.has_value()) {
+    std::string msg = format(R"(Node '{}' not found in schema for database '{}')",
+                             label, database_name);
+    throw std::runtime_error(msg);
+  }
+  return node_res.value().get();
+}
+
+void Schema::RemoveNode(const std::string& label) {
+  auto nodeIt = std::find_if(nodes.begin(), nodes.end(),
+                             [label](const Node& node) { return node.label == label; });
+  if (nodeIt == nodes.end()) {
+    std::string msg = format("Could not find node: "
+                             "Node \'{}\' not found in schema for database \'{}\'",
+                             label, database_name);
+    throw std::runtime_error(msg);
+  }
+  nodes.erase(nodeIt);
+
+  for (auto relIt = relationships.begin(); relIt != relationships.end(); ++relIt) {
+    if (relIt->start.label == label || relIt->end.label == label) {
+      relationships.erase(relIt);
+    }
+  }
+}
+void Schema::RemoveNodeProperty(const std::string& label, const std::string& property_name) {
+  auto& node = GetNodeOrThrow(label);
+  auto& properties  = node.properties;
+  auto propertyIt = std::find_if(properties.begin(), properties.end(),
+                                 [property_name](const Property& property) {
+                                   return property.name == property_name;
+                                 });
+  if (propertyIt == properties.end()) {
+    return;
+  }
+  int pi = std::distance(properties.begin(), propertyIt);
+  properties.erase(propertyIt);
+  RemovePropertyIdxFromConditions(label, pi);
+}
+void Schema::Clear() {
+  database_name.clear();
+  nodes.clear();
+  relationships.clear();
+}
+
+std::string Schema::ToJsonString(int indent, char indent_char) const {
   json schema_json;
   to_json(schema_json, *this);
   return schema_json.dump(indent, indent_char);
+}
+
+void Schema::RemovePropertyIdxFromConditions(const std::string& label, int pi) {
+  for (auto& relationship : relationships) {
+    if (relationship.start.label == label) {
+      relationship.RemoveConditionBySPI(pi);
+    } else if (relationship.end.label == label) {
+      relationship.RemoveConditionByEPI(pi);
+    }
+  }
 }
 
 } // scc::translator::cypher

--- a/src/translator/schema/schema.cpp
+++ b/src/translator/schema/schema.cpp
@@ -104,7 +104,7 @@ void Schema::RemoveNode(const std::string& label) {
   nodes.erase(nodeIt);
 
   for (auto relIt = relationships.begin(); relIt != relationships.end(); ++relIt) {
-    if (relIt->start.label == label || relIt->end.label == label) {
+    if (relIt->start == label || relIt->end == label) {
       relationships.erase(relIt);
     }
   }
@@ -151,9 +151,9 @@ std::string Schema::ToJsonString(int indent, char indent_char) const {
 
 void Schema::RemovePropertyIdxFromConditions(const std::string& label, int pi) {
   for (auto& relationship : relationships) {
-    if (relationship.start.label == label) {
+    if (relationship.start == label) {
       relationship.RemoveConditionBySPI(pi);
-    } else if (relationship.end.label == label) {
+    } else if (relationship.end == label) {
       relationship.RemoveConditionByEPI(pi);
     }
   }

--- a/src/translator/schema/schema.cpp
+++ b/src/translator/schema/schema.cpp
@@ -1,6 +1,6 @@
-#include "SCC/translator/cypher/schema.h"
+#include "SCC/translator/schema/schema.h"
 
-namespace scc::translator::cypher {
+namespace scc::translator::schema {
 
 Schema::Schema(std::string database_name) : database_name(std::move(database_name)) {}
 
@@ -13,7 +13,7 @@ void Schema::AddNode(const Node& node) {
   }
   nodes.push_back(node);
 }
-void Schema::AddConditionalRelationship(const ConditionalRelationship& relationship) {
+void Schema::AddConditionalRelationship(const Relationship& relationship) {
   auto it = std::find(relationships.begin(), relationships.end(), relationship);
   if (it != relationships.end()) {
     std::string msg = format(R"(Relationship '{}' already exists in schema for database '{}')",

--- a/src/translator/schema/schema.cpp
+++ b/src/translator/schema/schema.cpp
@@ -2,6 +2,8 @@
 
 namespace scc::translator::schema {
 
+using nlohmann::json;
+
 Schema::Schema(std::string database_name) : database_name(std::move(database_name)) {}
 
 void Schema::AddNode(const Node& node) {
@@ -21,6 +23,12 @@ void Schema::AddConditionalRelationship(const Relationship& relationship) {
     throw std::runtime_error(msg);
   }
   relationships.push_back(relationship);
+}
+
+std::string Schema::ToJsonString(const int indent, const char indent_char) const {
+  json schema_json;
+  to_json(schema_json, *this);
+  return schema_json.dump(indent, indent_char);
 }
 
 } // scc::translator::cypher

--- a/src/translator/schema/schema.cpp
+++ b/src/translator/schema/schema.cpp
@@ -123,6 +123,20 @@ void Schema::RemoveNodeProperty(const std::string& label, const std::string& pro
   properties.erase(propertyIt);
   RemovePropertyIdxFromConditions(label, pi);
 }
+void Schema::RemoveNodePropertyConstraints(const std::string& label,
+                                           const std::string& constraint_prefix) {
+  auto& node = GetNodeOrThrow(label);
+  auto& properties  = node.properties;
+  for (auto& property : properties) {
+    property.RemoveConstraintsByPrefix(constraint_prefix);
+  }
+}
+void Schema::RemoveRelationship(const std::string& type) {
+  std::remove_if(relationships.begin(), relationships.end(),
+                 [type](Relationship& relationship) {
+                   return relationship.type == type;
+                 });
+}
 void Schema::Clear() {
   database_name.clear();
   nodes.clear();

--- a/src/translator/translator.cpp
+++ b/src/translator/translator.cpp
@@ -9,17 +9,17 @@ template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
 
-Translator::Translator(NodePtr<INode> ast, const fs::path& out_path)
-    : ast_(std::move(ast)), schema_path_(out_path) {}
+Translator::Translator(NodePtr<INode> ast, const fs::path& out_path, bool translate_schema)
+    : ast_(std::move(ast)), translate_schema_(translate_schema), schema_path_(out_path) {}
 
-void Translator::Translate(bool translate_schema) {
+void Translator::Translate() {
   LOGI << "Translation is started";
   if (ast_ == nullptr || !HasChildren(ast_)) {
     LOGI << "Translation is ended. Nothing to translate";
     return;
   }
 
-  if (!translate_schema) {
+  if (!translate_schema_) {
     LOGW << "Currently only translation of schema migration queries is supported."
          << " Use --translate-schema flag to translate schema";
     return;

--- a/src/translator/translator.cpp
+++ b/src/translator/translator.cpp
@@ -3,19 +3,29 @@
 namespace scc::translator {
 
 using namespace ast;
+namespace fs = std::filesystem;
 
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
 
-Translator::Translator(NodePtr<INode> ast, const std::filesystem::path& out_path)
-    : ast_(std::move(ast)), out_(out_path) {}
+Translator::Translator(NodePtr<INode> ast, const fs::path& out_path)
+    : ast_(std::move(ast)), schema_path_(out_path) {}
 
-void Translator::Translate() {
+void Translator::Translate(bool translate_schema) {
   LOGI << "Translation is started";
   if (ast_ == nullptr || !HasChildren(ast_)) {
     LOGI << "Translation is ended. Nothing to translate";
     return;
+  }
+
+  if (!translate_schema) {
+    LOGW << "Currently only translation of schema migration queries is supported."
+         << " Use --translate-schema flag to translate schema";
+    return;
+  } else {
+    schema_path_.replace_extension(".json");
+    out_.open(schema_path_);
   }
 
   ValidateIsCorrectStmtType(ast_, StmtType::kProgram);
@@ -24,8 +34,11 @@ void Translator::Translate() {
     ValidateIsCorrectStmtType(query, StmtType::kQuery);
     TranslateQuery(query);
   }
-
   LOGI << "Translation is ended";
+
+  LOGI << "Serializing Neo4j schema to json...";
+  out_ << schema_.ToJsonString() << std::endl;
+  LOGI << "Serialized Neo4j schema saved at " << schema_path_.string();
 }
 
 void Translator::WriteCypherQuery(const std::string& query) {

--- a/src/translator/translator.cpp
+++ b/src/translator/translator.cpp
@@ -70,7 +70,9 @@ void Translator::TranslateQuery(const NodePtr<INode>& query) {
                                      statement_type->stmt_type.ToString()));
   }
 
-  FinishCypherQueriesGroup();
+  if (statement_type->stmt_type != StmtType::kDdlStmt) {
+    FinishCypherQueriesGroup();
+  }
 }
 
 } // scc::translator

--- a/test/config/scc_args_test.cpp
+++ b/test/config/scc_args_test.cpp
@@ -54,7 +54,7 @@ TEST_F(SCCArgsTests, CypherArgumentDefaultValueTest) {
   EXPECT_NO_THROW(ParseArgsWrapper());
 
   std::string default_cypher_file = parser.Get("--cypher");
-  EXPECT_TRUE(default_cypher_file.find("out.cypher") != std::string::npos);
+  EXPECT_TRUE(default_cypher_file.find("out.cql") != std::string::npos);
 }
 TEST_F(SCCArgsTests, CypherArgumentWithoutParameterTest) {
   GTEST_SKIP() << "Argument without value did not throw an exception.";

--- a/test/config/scc_args_test.cpp
+++ b/test/config/scc_args_test.cpp
@@ -50,6 +50,13 @@ TEST_F(SCCArgsBaseTests, SQLArgumentWithoutParameterTest) {
   EXPECT_THROW(ParseArgsWrapper(), std::runtime_error);
 }
 
+TEST_F(SCCArgsTests, TranslateSchemaDefaultValueTest) {
+  EXPECT_NO_THROW(ParseArgsWrapper());
+
+  bool default_translate_schema_flag = parser.Get<bool>("--translate-schema");
+  EXPECT_TRUE(default_translate_schema_flag);
+}
+
 TEST_F(SCCArgsTests, CypherArgumentDefaultValueTest) {
   EXPECT_NO_THROW(ParseArgsWrapper());
 

--- a/test/config/scc_config_test.cpp
+++ b/test/config/scc_config_test.cpp
@@ -55,7 +55,7 @@ TEST_F(SCCConfigTests, DefaultConfigTest) {
   fs::path default_sql_file = fs::canonical(sql_path);
   EXPECT_EQ(default_sql_file, config->get_sql_file());
 
-  fs::path default_cypher_file = fs::current_path() / "out.cypher";
+  fs::path default_cypher_file = fs::current_path() / "out.cql";
   EXPECT_EQ(default_cypher_file, config->get_cypher_file());
 
   EXPECT_TRUE(config->get_ast_dump_file().empty());

--- a/test/config/scc_config_test.cpp
+++ b/test/config/scc_config_test.cpp
@@ -52,6 +52,9 @@ TEST_F(SCCConfigTests, DefaultConfigTest) {
   SCCMode default_mode = SCCMode::kInteractive;
   EXPECT_EQ(default_mode, config->mode);
 
+  bool default_translate_schema_flag = true;
+  EXPECT_EQ(default_translate_schema_flag, config->translate_schema);
+
   fs::path default_sql_file = fs::canonical(sql_path);
   EXPECT_EQ(default_sql_file, config->get_sql_file());
 
@@ -61,6 +64,8 @@ TEST_F(SCCConfigTests, DefaultConfigTest) {
   EXPECT_TRUE(config->get_ast_dump_file().empty());
 }
 TEST_F(CustomSCCConfigTests, CustomConfigTest) {
+  AddArg("--translate-schema");
+
   std::string custom_sql_file = sql_path;
   AddArg("--sql", custom_sql_file);
 
@@ -81,6 +86,7 @@ TEST_F(CustomSCCConfigTests, CustomConfigTest) {
       InitializeConfig();
   );
 
+  EXPECT_EQ(true, config->translate_schema);
   EXPECT_EQ(fs::canonical(custom_sql_file), config->get_sql_file());
   EXPECT_EQ(logger::to_severity(custom_log_severity), config->log_severity);
   EXPECT_EQ(fs::weakly_canonical(fs::path{custom_log_directory}), config->log_directory);


### PR DESCRIPTION
Closes #52.

- Now `Property` in `cypher/graph` component is a separate class for `Node` and `Relationship`;
- Created new classes for schema migration queries translation like `Property`, `Node`, `Relationship`, `PropertyConstraint`, `ApplyCondition`;
- Translator now translates DDL queries to schema elements;
- Translator writes the schema in `out.json`in JSON format;
- Added `--translate-schema` flag to cmd arguments with unit-tests. **Idea:** if `--translate-schema` is present (now, its true by default), then Translator translates queries to schema in `out.json`; Btw in the future flag `--translate-data` will be added and Translator will translate DML queries and CSV files with data (according to schema) into Cypher queries.