### PR TITLE
[#55] Translate DML SQL queries to Cypher queries 

### DIFF
--- a/doc/ms_sql_grammar.bnf
+++ b/doc/ms_sql_grammar.bnf
@@ -63,7 +63,7 @@ or_condition  ::= and_condition ['OR' and_condition] ;
 and_condition ::= not_condition ['AND' not_condition] ;
 not_condition ::= ['NOT'] predicate ;
 predicate     ::= expr binary_operator_ expr ;
-expr          ::= name_list_ | (unary_operator_ expr) | ('(' expr ')') | string | math_expr ;
+expr          ::= name | (unary_operator_ expr) | ('(' expr ')') | string | math_expr | number;
 
 // Math Expressions (PEG)
 
@@ -71,10 +71,13 @@ math_expr ::= sum ;
 sum       ::= product [('+' | '-') product] ;
 product   ::= power [('*' | '/') power] ;
 power     ::= value ['^' power] ;
-value     ::= 'regexp:[0-9]+' | ('(' math_expr ')') ;
+value     ::= number | ('(' math_expr ')') ;
 
 // Base
 
+number     ::= integer | float ;
+integer    ::= 'regexp:[1-9][0-9]*'
+float      ::= 'regexp:[1-9][0-9]*.[0-9]'
 identifier ::= "regexp:[_a-zA-z0-9]+" ;
 string     ::= ("'" string_ "'") | ('"' string_ '"') ;
 

--- a/doc/ms_sql_grammar.bnf
+++ b/doc/ms_sql_grammar.bnf
@@ -61,7 +61,7 @@ data_type       ::= 'float' | ('int' | 'integer') | 'varchar' | 'char' ;
 condition     ::= or_condition ;
 or_condition  ::= and_condition ['OR' and_condition] ;
 and_condition ::= not_condition ['AND' not_condition] ;
-not_condition ::= 'NOT' predicate ;
+not_condition ::= ['NOT'] predicate ;
 predicate     ::= expr binary_operator_ expr ;
 expr          ::= name_list_ | (unary_operator_ expr) | ('(' expr ')') | string | math_expr ;
 

--- a/doc/ms_sql_grammar.bnf
+++ b/doc/ms_sql_grammar.bnf
@@ -21,9 +21,10 @@ alter_table_drop_list ::= alter_table_drop_element_ {',' alter_table_drop_elemen
 // DML Statements
 
 dml_stmt    ::= insert_stmt | update_stmt | delete_stmt
-insert_stmt ::= 'INSERT' // stub
-update_stmt ::= 'UPDATE' // stub
-delete_stmt ::= 'DELETE' // stub
+insert_stmt ::= 'INSERT' ['INTO'] table_name ['(' column_name_list_ ')']
+                'VALUES' '(' insert_values_list_ ')';
+update_stmt ::= 'UPDATE' table_name 'SET' update_column_list_ ['WHERE' condition] ;
+delete_stmt ::= 'DELETE' ['FROM'] table_name 'WHERE' condition ;
 
 // Helpers
 
@@ -37,6 +38,10 @@ alter_table_drop_column_     ::= 'COLUMN' column_name_list_ ;
 alter_table_drop_constraint_ ::= 'CONSTRAINT' constraint_name_list_ ;
 database_name_list_          ::= database_name {',' database_name} ;
 table_name_list_             ::= table_name {',' table_name} ;
+insert_values_list_          ::= insert_values_element_ {',' insert_values_element_} ;
+insert_values_element_       ::= '(' ('NULL' | expr) ')' ;
+update_column_list_          ::= update_column_element_ {',' update_column_element_} ;
+update_column_element_       ::= column_name '=' ('NULL' | expr) ;
 
 // Basic Statements
 

--- a/include/SCC/ast/stmt_types.h
+++ b/include/SCC/ast/stmt_types.h
@@ -58,12 +58,20 @@ constexpr std::string_view kST_COLUMN_KW = "column";
 constexpr std::string_view kST_REFERENCES_KW = "references";
 constexpr std::string_view kST_ADD_KW = "add";
 constexpr std::string_view kST_DROP_KW = "drop";
+constexpr std::string_view kST_INTO_KW = "into";
+constexpr std::string_view kST_SET_KW = "set";
+constexpr std::string_view kST_FROM_KW = "from";
+constexpr std::string_view kST_WHERE_KW = "where";
+constexpr std::string_view kST_VALUES_KW = "values";
 
 constexpr std::string_view kST_INT_TYPE = "int";
 constexpr std::string_view kST_INTEGER_TYPE = "integer";
 constexpr std::string_view kST_FLOAT_TYPE = "float";
 constexpr std::string_view kST_CHAR_TYPE = "char";
 constexpr std::string_view kST_VARCHAR_TYPE = "varchar";
+
+constexpr std::string_view kST_NULL_VALUE = "null";
+constexpr std::string_view kST_UNKNOWN_VALUE = "unknown";
 
 class StmtType {
 public:
@@ -125,12 +133,21 @@ public:
     kReferencesKW,
     kAddKW,
     kDropKW,
+    kIntoKW,
+    kSetKW,
+    kFromKW,
+    kWhereKW,
+    kValuesKW,
 
     // SQL Data Types
     kIntType,
     kFloatType,
     kCharType,
     kVarcharType,
+
+    // Special values
+    kNullValue,
+    kUnknownValue,
   };
 
   StmtType() = default;

--- a/include/SCC/ast/stmt_types.h
+++ b/include/SCC/ast/stmt_types.h
@@ -34,6 +34,7 @@ constexpr std::string_view kST_DELETE = "delete";
 constexpr std::string_view kST_INSERT = "insert";
 constexpr std::string_view kST_UPDATE = "update";
 
+constexpr std::string_view kST_UPDATE_COLUMN = "update column";
 constexpr std::string_view kST_CONDITION = "condition";
 constexpr std::string_view kST_OR_CONDITION = "or condition";
 constexpr std::string_view kST_AND_CONDITION = "and condition";
@@ -106,6 +107,7 @@ public:
     kUpdateStmt,
 
     // DML Basic Statements
+    kUpdateColumn,
     kCondition,
     kORCondition,
     kANDCondition,

--- a/include/SCC/ast/stmt_types.h
+++ b/include/SCC/ast/stmt_types.h
@@ -35,12 +35,19 @@ constexpr std::string_view kST_INSERT = "insert";
 constexpr std::string_view kST_UPDATE = "update";
 
 constexpr std::string_view kST_UPDATE_COLUMN = "update column";
+
 constexpr std::string_view kST_CONDITION = "condition";
 constexpr std::string_view kST_OR_CONDITION = "or condition";
 constexpr std::string_view kST_AND_CONDITION = "and condition";
 constexpr std::string_view kST_NOT_CONDITION = "not condition";
 constexpr std::string_view kST_PREDICATE = "predicate";
 constexpr std::string_view kST_EXPRESSION = "expression";
+
+constexpr std::string_view kST_MATH_EXPRESSION = "math expression";
+constexpr std::string_view kST_SUM = "sum";
+constexpr std::string_view kST_PRODUCT = "product";
+constexpr std::string_view kST_POWER = "power";
+constexpr std::string_view kST_VALUE = "value";
 
 constexpr std::string_view kST_OR_OPERATOR = "or";
 constexpr std::string_view kST_AND_OPERATOR = "and";
@@ -108,12 +115,19 @@ public:
 
     // DML Basic Statements
     kUpdateColumn,
+
     kCondition,
     kORCondition,
     kANDCondition,
     kNOTCondition,
     kPredicate,
     kExpression,
+
+    kMathExpression,
+    kSum,
+    kProduct,
+    kPower,
+    kValue,
 
     // Logical Operators
     kOROperator,

--- a/include/SCC/config/scc_config.h
+++ b/include/SCC/config/scc_config.h
@@ -22,16 +22,21 @@ public:
   fs::path log_directory;
   SCCMode mode;
   bool translate_schema;
+  bool translate_data;
 
   explicit SCCConfig(const SCCArgs& args);
 
   static SCCConfig* Get();
 
+  const std::filesystem::path& get_sql_schema_file() const;
+  const std::filesystem::path& get_graph_schema_file() const;
   const std::filesystem::path& get_sql_file() const;
   const std::filesystem::path& get_cypher_file() const;
   const std::filesystem::path& get_ast_dump_file() const;
 
 private:
+  std::filesystem::path sql_schema_file_;
+  std::filesystem::path graph_schema_file_;
   std::filesystem::path sql_file_;
   std::filesystem::path cypher_file_;
   std::filesystem::path ast_dump_file_;

--- a/include/SCC/lexer/lexer.h
+++ b/include/SCC/lexer/lexer.h
@@ -2,6 +2,7 @@
 
 #include <deque>
 #include <filesystem>
+#include <format>
 #include <sstream>
 
 #include "SCC/ast/nodes/inode.h"

--- a/include/SCC/parser/common/node_data_classifier.h
+++ b/include/SCC/parser/common/node_data_classifier.h
@@ -18,6 +18,7 @@ public:
   static bool IsUnaryOperator(const std::shared_ptr<ast::INode>& node);
   static bool IsBinaryOperator(const std::shared_ptr<ast::INode>& node);
   static bool IsSemicolon(const std::shared_ptr<ast::INode>& node);
+  static bool IsAssignmentOperator(const std::shared_ptr<ast::INode>& node);
 
 private:
   static bool IsCorrectDataType(const std::shared_ptr<ast::INode>& node_to_check,

--- a/include/SCC/parser/parser.h
+++ b/include/SCC/parser/parser.h
@@ -75,6 +75,8 @@ private:
   std::shared_ptr<ast::INode> ParseDeleteStatement();
   std::shared_ptr<ast::INode> ParseUpdateStatement();
 
+  std::shared_ptr<ast::INode> ParseInsertValuesList();
+
   std::shared_ptr<ast::INode> ParseCondition();
   std::shared_ptr<ast::INode> ParseORCondition();
   std::shared_ptr<ast::INode> ParseANDCondition();
@@ -115,6 +117,7 @@ private:
   std::shared_ptr<ast::INode> ParseString();
   std::shared_ptr<ast::INode> ParseName();
   std::shared_ptr<ast::INode> ParseIdentifier();
+  std::shared_ptr<ast::INode> ParseExpressionOrNull();
 
   bool HasTokens(unsigned min_count = 1) const;
   void ValidateHasTokens(const std::string& details = "") const;

--- a/include/SCC/parser/parser.h
+++ b/include/SCC/parser/parser.h
@@ -78,6 +78,9 @@ private:
   std::shared_ptr<ast::INode> ParseInsertValuesList();
   std::shared_ptr<ast::INode> ParseUpdateColumnElement();
 
+  std::shared_ptr<ast::INode> ParseExpressionOrNull();
+  std::shared_ptr<ast::INode> ParseWhereStatement();
+
   std::shared_ptr<ast::INode> ParseCondition();
   std::shared_ptr<ast::INode> ParseORCondition();
   std::shared_ptr<ast::INode> ParseANDCondition();
@@ -118,8 +121,6 @@ private:
   std::shared_ptr<ast::INode> ParseString();
   std::shared_ptr<ast::INode> ParseName();
   std::shared_ptr<ast::INode> ParseIdentifier();
-  std::shared_ptr<ast::INode> ParseExpressionOrNull();
-  std::shared_ptr<ast::INode> ParseWhereStatement();
 
   bool HasTokens(unsigned min_count = 1) const;
   void ValidateHasTokens(const std::string& details = "") const;

--- a/include/SCC/parser/parser.h
+++ b/include/SCC/parser/parser.h
@@ -72,10 +72,11 @@ private:
   void ParseAlterDropConstraints(std::shared_ptr<ast::INode>& parent);
 
   std::shared_ptr<ast::INode> ParseInsertStatement();
-  std::shared_ptr<ast::INode> ParseDeleteStatement();
   std::shared_ptr<ast::INode> ParseUpdateStatement();
+  std::shared_ptr<ast::INode> ParseDeleteStatement();
 
   std::shared_ptr<ast::INode> ParseInsertValuesList();
+  std::shared_ptr<ast::INode> ParseUpdateColumnElement();
 
   std::shared_ptr<ast::INode> ParseCondition();
   std::shared_ptr<ast::INode> ParseORCondition();
@@ -118,17 +119,21 @@ private:
   std::shared_ptr<ast::INode> ParseName();
   std::shared_ptr<ast::INode> ParseIdentifier();
   std::shared_ptr<ast::INode> ParseExpressionOrNull();
+  std::shared_ptr<ast::INode> ParseWhereStatement();
 
   bool HasTokens(unsigned min_count = 1) const;
   void ValidateHasTokens(const std::string& details = "") const;
   void ValidateHasTokens(unsigned min_count = 1) const;
   void ValidateHasNotTokens() const;
+
   void ValidateIsWord(const std::shared_ptr<ast::INode>& node) const;
   void ValidateIsOpeningRoundBracket(const std::shared_ptr<ast::INode>& node) const;
   void ValidateIsClosingRoundBracket(const std::shared_ptr<ast::INode>& node) const;
   void ValidateIsSingleQuote(const std::shared_ptr<ast::INode>& node) const;
   void ValidateIsDoubleQuote(const std::shared_ptr<ast::INode>& node) const;
   void ValidateIsBinaryOperator(const std::shared_ptr<ast::INode>& node) const;
+
+  void ValidateIsAssignmentOperator(const std::shared_ptr<ast::INode>& node) const;
 };
 
 } // scc::parser

--- a/include/SCC/translator/cypher/clauses/create.h
+++ b/include/SCC/translator/cypher/clauses/create.h
@@ -26,13 +26,18 @@ public:
 
 class CreateConstraintClauseBuilder {
 public:
-  static std::string Build(const std::string& constraint_name, const Node& node,
-                           const Property& property, ConstraintType type);
+  static std::string Build(const std::string& constraint_name, const std::string& label,
+                           const std::string& property_name, ConstraintType type);
 };
 
 class CreateRelationshipClauseBuilder {
 public:
   static std::string Build(const Relationship& relationship);
+  static std::string Build(const std::string& start,
+                           const std::string& start_prop,
+                           const std::string& end,
+                           const std::string& end_prop,
+                           const std::string& relationship_type);
 };
 
 } // scc::translator::cypher

--- a/include/SCC/translator/cypher/clauses/set.h
+++ b/include/SCC/translator/cypher/clauses/set.h
@@ -10,7 +10,7 @@ namespace scc::translator::cypher {
 
 class SetPropertyClauseBuilder {
 public:
-  static std::string Build(const Node& node, const Property& property);
+  static std::string Build(const std::string& label, const Property& property);
 };
 
 class RemovePropertyClauseBuilder {

--- a/include/SCC/translator/cypher/graph/property.h
+++ b/include/SCC/translator/cypher/graph/property.h
@@ -18,6 +18,7 @@ public:
   PropertyType type;
   std::string value;
 
+  explicit Property() = default;
   explicit Property(std::string name, std::string value, PropertyType type);
 
   std::string ToString() const;

--- a/include/SCC/translator/cypher/graph/property_types.h
+++ b/include/SCC/translator/cypher/graph/property_types.h
@@ -17,6 +17,7 @@ constexpr std::string_view kPT_Boolean = "BOOLEAN";
 constexpr std::string_view kPT_Float = "FLOAT";
 constexpr std::string_view kPT_Integer = "INTEGER";
 constexpr std::string_view kPT_String = "STRING";
+constexpr std::string_view kPT_Null = "NULL";
 
 class PropertyType {
 public:
@@ -26,6 +27,7 @@ public:
     kFloat,
     kInteger,
     kString,
+    kNull,
   };
 
   PropertyType() = default;

--- a/include/SCC/translator/schema/node.h
+++ b/include/SCC/translator/schema/node.h
@@ -31,6 +31,8 @@ public:
 
   bool Validate(const cypher::Node& node) const;
 
+  std::string ToJsonString(int indent = 2, char indent_char = ' ') const;
+
   bool operator==(const Node& other) const;
   bool operator!=(const Node& other) const;
 };

--- a/include/SCC/translator/schema/node.h
+++ b/include/SCC/translator/schema/node.h
@@ -18,6 +18,7 @@ public:
   std::string label;
   std::vector<Property> properties;
 
+  explicit Node() = default;
   explicit Node(std::string label);
   explicit Node(std::string label, std::vector<Property> properties);
 

--- a/include/SCC/translator/schema/node.h
+++ b/include/SCC/translator/schema/node.h
@@ -33,14 +33,4 @@ public:
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Node, label, properties)
 
-inline void to_json(nlohmann::json& j, const std::vector<Node>& nodes) {
-  j = nlohmann::json::array();
-  for (const auto& node : nodes) {
-    j.push_back(node);
-  }
-}
-inline void from_json(const nlohmann::json& j, std::vector<Node>& nodes) {
-  nodes = j.get<std::vector<Node>>();
-}
-
 } // scc::translator::schema

--- a/include/SCC/translator/schema/node.h
+++ b/include/SCC/translator/schema/node.h
@@ -9,6 +9,7 @@
 
 #include "nlohmann/json.hpp"
 
+#include "SCC/translator/cypher/graph/node.h"
 #include "SCC/translator/schema/property.h"
 
 namespace scc::translator::schema {
@@ -24,8 +25,11 @@ public:
 
   Node& AddProperty(const Property& property);
   bool HasProperty(const std::string& name) const;
+  const Property& FindPropertyOrThrow(const std::string& name) const;
   int PropertyIndex(const std::string& name) const;
   unsigned PropertyCount() const;
+
+  bool Validate(const cypher::Node& node) const;
 
   bool operator==(const Node& other) const;
   bool operator!=(const Node& other) const;

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -68,14 +68,4 @@ private:
   bool HasConstraint(const PropertyConstraint& constraint) const;
 };
 
-inline void to_json(nlohmann::json& j, const std::vector<Property>& properties) {
-  j = nlohmann::json::array();
-  for (const auto& property : properties) {
-    j.push_back(property);
-  }
-}
-inline void from_json(const nlohmann::json& j, std::vector<Property>& properties) {
-  properties = j.get<std::vector<Property>>();
-}
-
 } // scc::translator::schema

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -8,6 +8,7 @@
 #include "nlohmann/json.hpp"
 
 #include "SCC/translator/cypher/graph/constraint_types.h"
+#include "SCC/translator/cypher/graph/property.h"
 #include "SCC/translator/cypher/graph/property_types.h"
 
 namespace scc::translator::schema {
@@ -46,6 +47,8 @@ public:
   bool MustBeUnique() const;
   bool MustBeNotNull() const;
   const std::vector<PropertyConstraint>& Constraints() const;
+
+  bool Validate(const cypher::Property& property) const;
 
   bool operator==(const Property& other) const;
   bool operator!=(const Property& other) const;

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -20,16 +20,16 @@ public:
   inline bool operator==(const PropertyConstraint& other) const {
     return name == other.name && type == other.type;
   }
-};
 
-inline void to_json(nlohmann::json& j, const PropertyConstraint& constraint)  {
-  j["name"] = constraint.name;
-  j["type"] = constraint.type.ToString();
-}
-inline void from_json(const nlohmann::json& j, PropertyConstraint& constraint) {
-  j.at("name").get_to(constraint.name);
-  j.at("type").get_to(constraint.type);
-}
+  friend void to_json(nlohmann::json& j, const PropertyConstraint& constraint) {
+    j["name"] = constraint.name;
+    j["type"] = constraint.type.ToString();
+  }
+  friend void from_json(const nlohmann::json& j, PropertyConstraint& constraint) {
+    j.at("name").get_to(constraint.name);
+    constraint.type = cypher::ConstraintType(j.at("type"));
+  }
+};
 
 class Property {
 public:
@@ -44,6 +44,7 @@ public:
   void RemoveConstraintsByPrefix(const std::string& prefix);
   bool MustBeUnique() const;
   bool MustBeNotNull() const;
+  const std::vector<PropertyConstraint>& Constraints() const;
 
   bool operator==(const Property& other) const;
   bool operator!=(const Property& other) const;
@@ -55,7 +56,7 @@ public:
   }
   friend void from_json(const nlohmann::json& j, Property& property) {
     j.at("name").get_to(property.name);
-    j.at("type").get_to(property.type);
+    property.type = cypher::PropertyType(j.at("type"));
     j.at("constraints").get_to(property.constraints);
   }
 

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -50,6 +50,8 @@ public:
 
   bool Validate(const cypher::Property& property) const;
 
+  std::string ToJsonString(int indent = 2, char indent_char = ' ') const;
+
   bool operator==(const Property& other) const;
   bool operator!=(const Property& other) const;
 

--- a/include/SCC/translator/schema/property.h
+++ b/include/SCC/translator/schema/property.h
@@ -27,7 +27,7 @@ public:
   }
   friend void from_json(const nlohmann::json& j, PropertyConstraint& constraint) {
     j.at("name").get_to(constraint.name);
-    constraint.type = cypher::ConstraintType(j.at("type"));
+    constraint.type = cypher::ConstraintType(std::string(j.at("type")));
   }
 };
 
@@ -36,6 +36,7 @@ public:
   std::string name;
   cypher::PropertyType type;
 
+  explicit Property() = default;
   explicit Property(std::string name, cypher::PropertyType type);
   explicit Property(std::string name, cypher::PropertyType type,
                     std::vector<PropertyConstraint> constraints);
@@ -56,7 +57,7 @@ public:
   }
   friend void from_json(const nlohmann::json& j, Property& property) {
     j.at("name").get_to(property.name);
-    property.type = cypher::PropertyType(j.at("type"));
+    property.type = cypher::PropertyType(std::string(j.at("type")));
     j.at("constraints").get_to(property.constraints);
   }
 

--- a/include/SCC/translator/schema/relationship.h
+++ b/include/SCC/translator/schema/relationship.h
@@ -28,6 +28,7 @@ public:
   std::string start;
   std::string end;
 
+  explicit Relationship() = default;
   explicit Relationship(std::string type, std::string start, std::string end);
   explicit Relationship(std::string type, std::string start, std::string end,
                         std::vector<ApplyCondition> conditions);
@@ -35,6 +36,7 @@ public:
   Relationship& AddCondition(ApplyCondition condition);
   void RemoveConditionBySPI(int spi);
   void RemoveConditionByEPI(int epi);
+  const std::vector<ApplyCondition>& Conditions() const;
 
   bool operator==(const Relationship& other) const;
   bool operator!=(const Relationship& other) const;

--- a/include/SCC/translator/schema/relationship.h
+++ b/include/SCC/translator/schema/relationship.h
@@ -12,8 +12,8 @@
 namespace scc::translator::schema {
 
 struct ApplyCondition {
-  int spi;
-  int epi;
+  int spi = -1;
+  int epi = -1;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ApplyCondition, spi, epi)

--- a/include/SCC/translator/schema/relationship.h
+++ b/include/SCC/translator/schema/relationship.h
@@ -47,14 +47,4 @@ private:
   std::vector<ApplyCondition> conditions;
 };
 
-inline void to_json(nlohmann::json& j, const std::vector<Relationship>& relationships) {
-  j = nlohmann::json::array();
-  for (const auto& relationship : relationships) {
-    j.push_back(relationship);
-  }
-}
-inline void from_json(const nlohmann::json& j, std::vector<Relationship>& relationships) {
-  relationships = j.get<std::vector<Relationship>>();
-}
-
 } // scc::translator::schema

--- a/include/SCC/translator/schema/schema.h
+++ b/include/SCC/translator/schema/schema.h
@@ -34,6 +34,8 @@ public:
   const Node& FindNodeOrThrow(const std::string& label) const;
   std::optional<std::reference_wrapper<Node>> GetNode(const std::string& label);
   Node& GetNodeOrThrow(const std::string& label);
+  const std::vector<Node>& Nodes() const;
+  const std::vector<Relationship>& Relationships() const;
 
   void RemoveNode(const std::string& label);
   void RemoveNodeProperty(const std::string& label, const std::string& property_name);
@@ -52,6 +54,7 @@ private:
   void RemovePropertyIdxFromConditions(const std::string& label, int pi);
 };
 
+bool operator==(const Schema& lhs, const Schema& rhs);
 std::ifstream& operator>>(std::ifstream& is, Schema& schema);
 
 } // scc::translator::cypher

--- a/include/SCC/translator/schema/schema.h
+++ b/include/SCC/translator/schema/schema.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <format>
+#include <fstream>
 #include <functional>
 #include <optional>
 #include <stdexcept>
@@ -50,5 +51,7 @@ private:
 
   void RemovePropertyIdxFromConditions(const std::string& label, int pi);
 };
+
+std::ifstream& operator>>(std::ifstream& is, Schema& schema);
 
 } // scc::translator::cypher

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -95,6 +95,9 @@ private:
   std::string GetName(const std::shared_ptr<ast::INode>& name_node) const;
   std::string GetIdentifier(const std::shared_ptr<ast::INode>& node) const;
 
+  std::pair<cypher::PropertyType, std::string>
+  TranslateExpression(const std::shared_ptr<ast::INode>& expr) const;
+
   std::string TranslateMathExpression(const std::shared_ptr<ast::INode>& expr) const;
   std::string TranslateMathSum(const std::shared_ptr<ast::INode>& sum) const;
   std::string TranslateMathProduct(const std::shared_ptr<ast::INode>& product) const;

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -2,11 +2,13 @@
 
 #include <algorithm>
 #include <iostream>
+#include <fstream>
 #include <filesystem>
 #include <format>
 #include <memory>
 #include <tuple>
 #include <string>
+#include <stdexcept>
 #include <sstream>
 #include <vector>
 #include <utility>
@@ -31,14 +33,16 @@ public:
 
 class Translator {
 public:
-  explicit Translator(std::shared_ptr<ast::INode> ast, const std::filesystem::path& out_path,
-                      bool translate_schema);
+  explicit Translator(std::shared_ptr<ast::INode> ast, const std::filesystem::path& out_path);
+  explicit Translator(std::shared_ptr<ast::INode> ast, std::filesystem::path graph_schema_path,
+                      const std::filesystem::path& out_path);
 
   void Translate();
 
 private:
   std::shared_ptr<ast::INode> ast_;
-  bool translate_schema_;
+  bool translate_schema_ = false;
+  bool translate_data_ = false;
   schema::Schema schema_;
   std::filesystem::path schema_path_;
   std::ofstream out_;

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -95,6 +95,12 @@ private:
   std::string GetName(const std::shared_ptr<ast::INode>& name_node) const;
   std::string GetIdentifier(const std::shared_ptr<ast::INode>& node) const;
 
+  std::string TranslateMathExpression(const std::shared_ptr<ast::INode>& expr) const;
+  std::string TranslateMathSum(const std::shared_ptr<ast::INode>& sum) const;
+  std::string TranslateMathProduct(const std::shared_ptr<ast::INode>& product) const;
+  std::string TranslateMathPower(const std::shared_ptr<ast::INode>& power) const;
+  std::string TranslateMathValue(const std::shared_ptr<ast::INode>& value) const;
+
   void AddPropertyConstraints(const std::string& constraint_name_prefix, const std::string& label,
                               const std::string& property_name,
                               const std::vector<cypher::ConstraintType>& constraint_types);

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -17,6 +17,9 @@
 #include "SCC/config/scc_config.h"
 #include "SCC/log/log.h"
 #include "SCC/parser/parser.h"
+#include "SCC/translator/cypher/clauses/create.h"
+#include "SCC/translator/cypher/graph/node.h"
+#include "SCC/translator/cypher/graph/property.h"
 #include "SCC/translator/schema/node.h"
 #include "SCC/translator/schema/property.h"
 #include "SCC/translator/schema/relationship.h"
@@ -81,9 +84,9 @@ private:
 
   // DML statements
 
-  void TranslateInsertStatement(const std::shared_ptr<ast::INode>& insert_stmt);
-  void TranslateDeleteStatement(const std::shared_ptr<ast::INode>& delete_stmt);
-  void TranslateUpdateStatement(const std::shared_ptr<ast::INode>& update_stmt);
+  void TranslateInsertStatement(const std::shared_ptr<ast::INode>& stmt);
+  void TranslateDeleteStatement(const std::shared_ptr<ast::INode>& stmt);
+  void TranslateUpdateStatement(const std::shared_ptr<ast::INode>& stmt);
 
   // Basic statements
 

--- a/include/SCC/translator/translator.h
+++ b/include/SCC/translator/translator.h
@@ -18,6 +18,7 @@
 #include "SCC/log/log.h"
 #include "SCC/parser/parser.h"
 #include "SCC/translator/cypher/clauses/create.h"
+#include "SCC/translator/cypher/clauses/set.h"
 #include "SCC/translator/cypher/graph/node.h"
 #include "SCC/translator/cypher/graph/property.h"
 #include "SCC/translator/schema/node.h"
@@ -85,8 +86,8 @@ private:
   // DML statements
 
   void TranslateInsertStatement(const std::shared_ptr<ast::INode>& stmt);
-  void TranslateDeleteStatement(const std::shared_ptr<ast::INode>& stmt);
   void TranslateUpdateStatement(const std::shared_ptr<ast::INode>& stmt);
+  void TranslateDeleteStatement(const std::shared_ptr<ast::INode>& stmt);
 
   // Basic statements
 

--- a/src/ast/stmt_types.cpp
+++ b/src/ast/stmt_types.cpp
@@ -61,6 +61,8 @@ StmtType::StmtType(const std::string_view& str_type) {
     this->value_ = kUpdateStmt;
 
   /* DML Basic Statements */
+  else if (type == kST_UPDATE_COLUMN)
+    this->value_ = kUpdateColumn;
   else if (type == kST_CONDITION)
     this->value_ = kCondition;
   else if (type == kST_OR_CONDITION)
@@ -192,6 +194,8 @@ std::string StmtType::ToString() const {
       return std::string(kST_UPDATE);
 
     /* DML Basic Statements */
+    case kUpdateColumn:
+      return std::string(kST_UPDATE_COLUMN);
     case kCondition:
       return std::string(kST_CONDITION);
     case kORCondition:

--- a/src/ast/stmt_types.cpp
+++ b/src/ast/stmt_types.cpp
@@ -3,7 +3,7 @@
 namespace scc::ast {
 
 StmtType::StmtType(Value value) {
-  if (value > kVarcharType)
+  if (value > kUnknownValue)
     throw std::invalid_argument("Incorrect value for Statement Type");
   this->value_ = value;
 }
@@ -63,6 +63,7 @@ StmtType::StmtType(const std::string_view& str_type) {
   /* DML Basic Statements */
   else if (type == kST_UPDATE_COLUMN)
     this->value_ = kUpdateColumn;
+
   else if (type == kST_CONDITION)
     this->value_ = kCondition;
   else if (type == kST_OR_CONDITION)
@@ -75,6 +76,17 @@ StmtType::StmtType(const std::string_view& str_type) {
     this->value_ = kPredicate;
   else if (type == kST_EXPRESSION)
     this->value_ = kExpression;
+
+  else if (type == kST_MATH_EXPRESSION)
+    this->value_ = kMathExpression;
+  else if (type == kST_SUM)
+    this->value_ = kSum;
+  else if (type == kST_PRODUCT)
+    this->value_ = kProduct;
+  else if (type == kST_POWER)
+    this->value_ = kPower;
+  else if (type == kST_VALUE)
+    this->value_ = kValue;
 
   /* Logical Operators */
   else if (type == kST_OR_OPERATOR)
@@ -196,6 +208,7 @@ std::string StmtType::ToString() const {
     /* DML Basic Statements */
     case kUpdateColumn:
       return std::string(kST_UPDATE_COLUMN);
+
     case kCondition:
       return std::string(kST_CONDITION);
     case kORCondition:
@@ -208,6 +221,17 @@ std::string StmtType::ToString() const {
       return std::string(kST_PREDICATE);
     case kExpression:
       return std::string(kST_EXPRESSION);
+
+    case kMathExpression:
+      return std::string(kST_MATH_EXPRESSION);
+    case kSum:
+      return std::string(kST_SUM);
+    case kProduct:
+      return std::string(kST_PRODUCT);
+    case kPower:
+      return std::string(kST_POWER);
+    case kValue:
+      return std::string(kST_VALUE);
 
     /* Logical Operators */
     case kOROperator:
@@ -264,6 +288,11 @@ std::string StmtType::ToString() const {
       return std::string(kST_CHAR_TYPE);
     case kVarcharType:
       return std::string(kST_VARCHAR_TYPE);
+
+    case kNullValue:
+      return std::string(kST_NULL_VALUE);
+    case kUnknownValue:
+      return std::string(kST_UNKNOWN_VALUE);
   }
 }
 

--- a/src/ast/stmt_types.cpp
+++ b/src/ast/stmt_types.cpp
@@ -107,6 +107,16 @@ StmtType::StmtType(const std::string_view& str_type) {
     this->value_ = kAddKW;
   else if (type == kST_DROP_KW)
     this->value_ = kDropKW;
+  else if (type == kST_INTO_KW)
+    this->value_ = kIntoKW;
+  else if (type == kST_SET_KW)
+    this->value_ = kSetKW;
+  else if (type == kST_FROM_KW)
+    this->value_ = kFromKW;
+  else if (type == kST_WHERE_KW)
+    this->value_ = kWhereKW;
+  else if (type == kST_VALUES_KW)
+    this->value_ = kValuesKW;
 
   /* SQL Data Types */
   else if (type == kST_INT_TYPE || type == kST_INTEGER_TYPE)
@@ -117,6 +127,13 @@ StmtType::StmtType(const std::string_view& str_type) {
     this->value_ = kCharType;
   else if (type == kST_VARCHAR_TYPE)
     this->value_ = kVarcharType;
+
+  /* Special values */
+  else if (type == kST_NULL_VALUE)
+    this->value_ = kNullValue;
+  else if (type == kST_UNKNOWN_VALUE)
+    this->value_ = kUnknownValue;
+
   else
     throw std::invalid_argument("No Statement Type for '" + std::string(str_type) + "'");
 }
@@ -223,6 +240,16 @@ std::string StmtType::ToString() const {
       return std::string(kST_ADD_KW);
     case kDropKW:
       return std::string(kST_DROP_KW);
+    case kIntoKW:
+      return std::string(kST_INTO_KW);
+    case kSetKW:
+      return std::string(kST_SET_KW);
+    case kFromKW:
+      return std::string(kST_FROM_KW);
+    case kWhereKW:
+      return std::string(kST_WHERE_KW);
+    case kValuesKW:
+      return std::string(kST_VALUES_KW);
 
     /* SQL Data Types */
     case kIntType:

--- a/src/config/scc_args.cpp
+++ b/src/config/scc_args.cpp
@@ -32,12 +32,27 @@ SCCArgs::SCCArgs() : ArgumentParser(PROGRAM_NAME, VERSION, argparse::default_arg
 
   add_argument("--translate-schema")
       .help("Use this option to translate SQL schema migration queries into Cypher")
-      .default_value(true)
+      .default_value(false)
+      .implicit_value(true);
+
+  add_argument("--sql-schema")
+      .help("Specify path to the file with SQL schema migration queries to be converted")
+      .metavar("FILENAME");
+
+  std::string default_graph_schema_file =
+      (std::filesystem::current_path() / "schema.json").string();
+  add_argument("--graph-schema")
+      .help("Specify path to the file with Neo4j graph schema")
+      .metavar("FILENAME")
+      .default_value(default_graph_schema_file);
+
+  add_argument("--translate-data")
+      .help("Use this option to translate SQL data migration queries into Cypher")
+      .default_value(false)
       .implicit_value(true);
 
   add_argument("--sql")
-      .required()
-      .help("Specify path to the file with SQL queries to be converted")
+      .help("Specify path to the file with SQL data migration queries to be converted")
       .metavar("FILENAME");
 
   std::string default_cypher_file = (std::filesystem::current_path() / "out.cql").string();

--- a/src/config/scc_config.cpp
+++ b/src/config/scc_config.cpp
@@ -31,11 +31,28 @@ SCCConfig::SCCConfig(const SCCArgs& args) {
       mode = args.Get<SCCMode>("--mode");
 
     translate_schema = args.Get<bool>("--translate-schema");
+    if (translate_schema) {
+      std::string sql_schema_file_path = args.Get("--sql-schema");
+      scc::common::ValidateFileExists(sql_schema_file_path);
+      sql_schema_file_ = fs::canonical(sql_schema_file_path);
+    }
+    graph_schema_file_ = fs::weakly_canonical(args.Get("--graph-schema"));
 
-    std::string sql_file_path = args.Get("--sql");
-    scc::common::ValidateFileExists(sql_file_path);
-    sql_file_ = fs::canonical(sql_file_path);
-    cypher_file_ = fs::weakly_canonical(args.Get("--cypher"));
+    translate_data = args.Get<bool>("--translate-data");
+    if (translate_data) {
+      if (!translate_schema) {
+        scc::common::ValidateFileExists(graph_schema_file_);
+      }
+      std::string sql_file_path = args.Get("--sql");
+      scc::common::ValidateFileExists(sql_file_path);
+      sql_file_ = fs::canonical(sql_file_path);
+      cypher_file_ = fs::weakly_canonical(args.Get("--cypher"));
+    }
+
+    if (!(translate_schema || translate_data)) {
+      throw std::logic_error("Either --translate-schema or --translate-data must be specified");
+    }
+
     if (args.IsUsed("--dump"))
       ast_dump_file_ = fs::weakly_canonical(args.Get("--dump"));
   } catch (const std::logic_error& e) {
@@ -52,6 +69,12 @@ SCCConfig* SCCConfig::Get() {
   return instance;
 }
 
+const fs::path& SCCConfig::get_sql_schema_file() const {
+  return sql_schema_file_;
+}
+const fs::path& SCCConfig::get_graph_schema_file() const {
+  return graph_schema_file_;
+}
 const fs::path& SCCConfig::get_sql_file() const {
   return sql_file_;
 }

--- a/src/lexer/lexer.cpp
+++ b/src/lexer/lexer.cpp
@@ -3,6 +3,7 @@
 namespace scc::lexer {
 
 using namespace ast;
+using std::format;
 
 Lexer::Lexer(const std::filesystem::path& input_path)
     : input_(input_path) {}
@@ -48,10 +49,7 @@ std::shared_ptr<INode> Lexer::GetToken(char symbol, SymbolType sym_type) {
     case SymbolType::kNullTerminator:
       return nullptr;
     default:
-      std::string msg = "Unknown symbol \'"
-          + std::to_string(symbol)
-          + "\' in line "
-          + std::to_string(line_);
+      std::string msg = format("Unknown symbol \'{}\' at line", symbol, line_);
       LOGE << msg;
       throw std::invalid_argument(msg);
   }
@@ -95,7 +93,8 @@ std::shared_ptr<INode> Lexer::GetWord() {
   char symbol = PeekSymbol();
   while (SymbolClassifier::IsAlpha(symbol)
       || SymbolClassifier::IsDigit(symbol)
-      || symbol == '_') {
+      || symbol == '_'
+      || symbol == '@') {
     data += GetSymbol();
     symbol = PeekSymbol();
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,20 +10,33 @@ int main(int argc, char* argv[]) {
 
     logger::init(config->log_severity, config->log_directory);
 
-    scc::lexer::Lexer lexer(config->get_sql_file());
-    std::deque<std::shared_ptr<scc::ast::INode>> tokens = lexer.Analyze();
+    if (config->translate_schema) {
+      scc::lexer::Lexer lexer(config->get_sql_schema_file());
+      std::deque<std::shared_ptr<scc::ast::INode>> tokens = lexer.Analyze();
 
-    scc::parser::Parser parser(std::move(tokens));
-    std::shared_ptr<scc::ast::INode> AST = parser.Parse();
+      scc::parser::Parser parser(std::move(tokens));
+      std::shared_ptr<scc::ast::INode> AST = parser.Parse();
 
-    if (scc_args.IsUsed("--dump")) {
-      scc::dump::TreeDump dump(config->get_ast_dump_file());
-      dump.DumpTree(AST);
+      if (scc_args.IsUsed("--dump")) {
+        scc::dump::TreeDump dump(config->get_ast_dump_file());
+        dump.DumpTree(AST);
+      }
+
+      scc::translator::Translator schema_translator(AST, config->get_graph_schema_file());
+      schema_translator.Translate();
     }
 
-    scc::translator::Translator translator(AST, config->get_cypher_file(),
-                                           config->translate_schema);
-    translator.Translate();
+    if (config->translate_data) {
+      scc::lexer::Lexer lexer(config->get_sql_file());
+      std::deque<std::shared_ptr<scc::ast::INode>> tokens = lexer.Analyze();
+
+      scc::parser::Parser parser(std::move(tokens));
+      std::shared_ptr<scc::ast::INode> AST = parser.Parse();
+
+      scc::translator::Translator data_translator(AST, config->get_graph_schema_file(),
+                                                  config->get_cypher_file());
+      data_translator.Translate();
+    }
 
     end(EXIT_SUCCESS);
   } catch (const std::exception& e) {

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -305,36 +305,5 @@ NodePtr<INode> Parser::ParseIdentifier() {
 
   return service_node;
 }
-NodePtr<INode> Parser::ParseExpressionOrNull() {
-  try {
-    auto peeked_token = PeekToken();
-    if (NodeDataTypeClassifier::IsWord(peeked_token)) {
-      std::string null_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
-      StmtType null_value(null_word);
-      if (null_value == StmtType::kNullValue) {
-        return ASTUtils::CreateServiceNode(StmtType::kNullValue, NextToken());
-      }
-    }
-  } catch (const std::invalid_argument& ignored) {}
-  return ParseExpression();
-}
-
-NodePtr<INode> Parser::ParseWhereStatement() {
-  auto peeked_token = PeekToken();
-  std::string next_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
-  std::string invalid_where_keyword_error = format("Expected \'WHERE\' keyword at line {}",
-                                                   peeked_token->line);
-  try {
-    StmtType where_kw(next_word);
-    if (where_kw != StmtType::kWhereKW) {
-      throw parsing_error(invalid_where_keyword_error);
-    }
-    NextToken();
-  } catch (const std::invalid_argument& ignored) {
-    throw parsing_error(invalid_where_keyword_error);
-  }
-
-  return ParseCondition();
-}
 
 } // scc::parser

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -306,5 +306,18 @@ NodePtr<INode> Parser::ParseIdentifier() {
 
   return service_node;
 }
+NodePtr<INode> Parser::ParseExpressionOrNull() {
+  try {
+    auto peeked_token = PeekToken();
+    if (NodeDataTypeClassifier::IsWord(peeked_token)) {
+      std::string null_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
+      StmtType null_value(null_word);
+      if (null_value == StmtType::kNullValue) {
+        return ASTUtils::CreateServiceNode(StmtType::kNullValue, NextToken());
+      }
+    }
+  } catch (const std::invalid_argument& ignored) {}
+  return ParseExpression();
+}
 
 } // scc::parser

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -320,4 +320,22 @@ NodePtr<INode> Parser::ParseExpressionOrNull() {
   return ParseExpression();
 }
 
+NodePtr<INode> Parser::ParseWhereStatement() {
+  auto peeked_token = PeekToken();
+  std::string next_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
+  std::string invalid_where_keyword_error = format("Expected \'WHERE\' keyword at line {}",
+                                                   peeked_token->line);
+  try {
+    StmtType where_kw(next_word);
+    if (where_kw != StmtType::kWhereKW) {
+      throw parsing_error(invalid_where_keyword_error);
+    }
+    NextToken();
+  } catch (const std::invalid_argument& ignored) {
+    throw parsing_error(invalid_where_keyword_error);
+  }
+
+  return ParseCondition();
+}
+
 } // scc::parser

--- a/src/parser/common/basic_statements.cpp
+++ b/src/parser/common/basic_statements.cpp
@@ -245,8 +245,7 @@ NodePtr<INode> Parser::ParseString() {
   NodePtr<StringNode> string = ASTUtils::CastToNodeType<StringNode>(
       ASTUtils::CreateStringNode("", DataType::kString)
   );
-  auto peeked_token = PeekToken();
-  while (!NodeDataClassifier::IsSingleQuote(peeked_token)) {
+  while (!NodeDataClassifier::IsSingleQuote(PeekToken())) {
     NodePtr<INode> next_word = NextToken();
     if (!string->data.empty()) {
       string->data += " "; // TODO: Lexer should save whitespace characters.

--- a/src/parser/common/node_data_classifier.cpp
+++ b/src/parser/common/node_data_classifier.cpp
@@ -57,6 +57,10 @@ bool NodeDataClassifier::IsSemicolon(const NodePtr<INode>& node) {
   return IsCorrectDataType(node, DataType::kPunctuation)
       && ASTUtils::CastToNodeType<CharNode>(node)->data == ';';
 }
+bool NodeDataClassifier::IsAssignmentOperator(const std::shared_ptr<ast::INode>& node) {
+  return IsCorrectDataType(node, DataType::kOperator)
+      && ASTUtils::CastToNodeType<StringNode>(node)->data  == "=";
+}
 
 bool NodeDataClassifier::IsCorrectDataType(const NodePtr<INode>& node_to_check,
                                            DataType correct_data_type) {

--- a/src/parser/common/validation.cpp
+++ b/src/parser/common/validation.cpp
@@ -73,4 +73,11 @@ void Parser::ValidateIsBinaryOperator(const NodePtr<INode>& node) const {
   }
 }
 
+void Parser::ValidateIsAssignmentOperator(const NodePtr<INode>& node) const {
+  if (!NodeDataClassifier::IsAssignmentOperator(node)) {
+    std::string msg = format("Expected Assignment Operator at line {}", node->line);
+    throw parsing_error(msg);
+  }
+}
+
 } // scc::parser

--- a/src/parser/dml/conditions.cpp
+++ b/src/parser/dml/conditions.cpp
@@ -139,8 +139,6 @@ NodePtr<INode> Parser::ParseExpression() {
 
   // Is it string ?
   if (NodeDataClassifier::IsQuote(PeekToken())) {
-    NextToken();
-
     ValidateHasTokens(format("Incorrect expression at line {}:"
                              "expected string literal or closing quote", peeked_token->line));
     NodePtr<INode> string = ParseString();

--- a/src/parser/dml/conditions.cpp
+++ b/src/parser/dml/conditions.cpp
@@ -147,6 +147,13 @@ NodePtr<INode> Parser::ParseExpression() {
     return service_node;
   }
 
+  // Is it number?
+  if (NodeDataTypeClassifier::IsNumber(peeked_token)) {
+    auto number = NextToken();
+    ASTUtils::Link(service_node, number);
+    return service_node;
+  }
+
   // It is Math expression
   NodePtr<INode> math_expression = ParseMathExpression();
   ASTUtils::Link(service_node, math_expression);

--- a/src/parser/dml/dml_statements.cpp
+++ b/src/parser/dml/dml_statements.cpp
@@ -218,12 +218,11 @@ NodePtr<INode> Parser::ParseUpdateColumnElement() {
   ValidateHasTokens(format("Missing assignment operator at line {}", column_name->line));
   auto assignment_operator = NextToken();
   ValidateIsAssignmentOperator(assignment_operator);
-  ASTUtils::Link(service_node, assignment_operator);
-  ASTUtils::Link(assignment_operator, column_name);
+  ASTUtils::Link(service_node, column_name);
 
   ValidateHasTokens(format("Missing value for column at line {}", assignment_operator->line));
   auto expression_or_null = ParseExpressionOrNull();
-  ASTUtils::Link(assignment_operator, expression_or_null);
+  ASTUtils::Link(service_node, expression_or_null);
 
   return service_node;
 }

--- a/src/parser/dml/dml_statements.cpp
+++ b/src/parser/dml/dml_statements.cpp
@@ -53,13 +53,104 @@ NodePtr<INode> Parser::ParseDMLStatement() {
 }
 
 NodePtr<INode> Parser::ParseInsertStatement() {
-  return ASTUtils::CreateServiceNode(StmtType::kInsertStmt);
+  NodePtr<INode> service_node = ASTUtils::CreateServiceNode(StmtType::kInsertStmt);
+
+  auto peeked_token = PeekToken();
+  ValidateIsWord(peeked_token);
+  std::string next_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
+  try {
+    StmtType into_kw(next_word);
+    if (into_kw != StmtType::kIntoKW) {
+      throw parsing_error(format("Expected \'INTO\' keyword at line {}", peeked_token->line));
+    }
+    NextToken();
+  } catch (const std::invalid_argument& ignored) {}
+
+  ValidateHasTokens(format("Missing table name at line {}", peeked_token->line));
+  NodePtr<INode> table_name = ParseTableName();
+  ASTUtils::Link(service_node, table_name);
+
+  ValidateHasTokens(format("Incorrect \'INSERT\' statement: "
+                           "expected column list or \'VALUES\' keyword at line {}",
+                           peeked_token->line));
+  peeked_token = PeekToken();
+  if (NodeDataClassifier::IsOpeningRoundBracket(peeked_token)) {
+    auto next_token = NextToken();
+    ValidateHasTokens(format("Missing column list where to insert at line {}", next_token->line));
+
+    while (HasTokens()) {
+      auto column_name = ParseColumnName();
+      ASTUtils::Link(service_node, column_name);
+
+      if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
+        next_token = NextToken();
+        ValidateHasTokens(format("Missing column name after comma at line {}", next_token->line));
+        ValidateIsWord(PeekToken());
+      } else {
+        break;
+      }
+    }
+
+    ValidateHasTokens(format("Missing closing round bracket at line {}", next_token->line));
+    peeked_token = PeekToken();
+    ValidateIsClosingRoundBracket(NextToken());
+  }
+
+  ValidateHasTokens(format("Missing VALUES clause at line {}", peeked_token->line));
+  peeked_token = PeekToken();
+  ValidateIsWord(peeked_token);
+  auto values_list = ParseInsertValuesList();
+  ASTUtils::Link(service_node, values_list);
+
+  return service_node;
 }
 NodePtr<INode> Parser::ParseDeleteStatement() {
   return ASTUtils::CreateServiceNode(StmtType::kDeleteStmt);
 }
 NodePtr<INode> Parser::ParseUpdateStatement() {
   return ASTUtils::CreateServiceNode(StmtType::kUpdateStmt);
+}
+
+NodePtr<INode> Parser::ParseInsertValuesList() {
+  auto peeked_token = PeekToken();
+  std::string values_keyword = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
+  std::string invalid_values_keyword_error = format("Expected \'VALUES\' keyword at line {}",
+                                                    peeked_token->line);
+  try {
+    StmtType values_kw(values_keyword);
+    if (values_kw != StmtType::kValuesKW) {
+      throw parsing_error(invalid_values_keyword_error);
+    }
+    NextToken();
+  } catch (const std::invalid_argument& ignored) {
+    throw parsing_error(invalid_values_keyword_error);
+  }
+  auto values_list = ASTUtils::CreateServiceNode(StmtType::kValuesKW);
+
+  ValidateHasTokens(format("Incorrect \'INSERT\' statement: expected expression list at line {}",
+                           values_list->line));
+  peeked_token = PeekToken();
+  if (NodeDataClassifier::IsOpeningRoundBracket(peeked_token)) {
+    auto next_token = NextToken();
+    ValidateHasTokens(format("Missing expression list at line {}", next_token->line));
+
+    while (HasTokens()) {
+      auto expression_or_null = ParseExpressionOrNull();
+      ASTUtils::Link(values_list, expression_or_null);
+
+      if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
+        next_token = NextToken();
+        ValidateHasTokens(format("Missing expression after comma at line {}", next_token->line));
+      } else {
+        break;
+      }
+    }
+
+    ValidateHasTokens(format("Missing closing round bracket at line {}", next_token->line));
+    ValidateIsClosingRoundBracket(NextToken());
+  }
+
+  return values_list;
 }
 
 } // scc::parser

--- a/src/parser/dml/dml_statements.cpp
+++ b/src/parser/dml/dml_statements.cpp
@@ -228,4 +228,35 @@ NodePtr<INode> Parser::ParseUpdateColumnElement() {
   return service_node;
 }
 
+NodePtr<INode> Parser::ParseExpressionOrNull() {
+  try {
+    auto peeked_token = PeekToken();
+    if (NodeDataTypeClassifier::IsWord(peeked_token)) {
+      std::string null_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
+      StmtType null_value(null_word);
+      if (null_value == StmtType::kNullValue) {
+        return ASTUtils::CreateServiceNode(StmtType::kNullValue, NextToken());
+      }
+    }
+  } catch (const std::invalid_argument& ignored) {}
+  return ParseExpression();
+}
+NodePtr<INode> Parser::ParseWhereStatement() {
+  auto peeked_token = PeekToken();
+  std::string next_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
+  std::string invalid_where_keyword_error = format("Expected \'WHERE\' keyword at line {}",
+                                                   peeked_token->line);
+  try {
+    StmtType where_kw(next_word);
+    if (where_kw != StmtType::kWhereKW) {
+      throw parsing_error(invalid_where_keyword_error);
+    }
+    NextToken();
+  } catch (const std::invalid_argument& ignored) {
+    throw parsing_error(invalid_where_keyword_error);
+  }
+
+  return ParseCondition();
+}
+
 } // scc::parser

--- a/src/parser/dml/dml_statements.cpp
+++ b/src/parser/dml/dml_statements.cpp
@@ -104,11 +104,47 @@ NodePtr<INode> Parser::ParseInsertStatement() {
 
   return service_node;
 }
+NodePtr<INode> Parser::ParseUpdateStatement() {
+  auto service_node = ASTUtils::CreateServiceNode(StmtType::kUpdateStmt);
+
+  NodePtr<INode> table_name = ParseTableName();
+  ASTUtils::Link(service_node, table_name);
+
+  auto peeked_token = PeekToken();
+  ValidateIsWord(peeked_token);
+  std::string next_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
+  try {
+    StmtType set_kw(next_word);
+    if (set_kw != StmtType::kSetKW) {
+      throw parsing_error(format("Expected \'SET\' keyword at line {}", peeked_token->line));
+    }
+    NextToken();
+  } catch (const std::invalid_argument& ignored) {}
+
+  ValidateHasTokens(format("Missing update columns list at line {}", peeked_token->line));
+  while (HasTokens()) {
+    auto update_column_element = ParseUpdateColumnElement();
+    ASTUtils::Link(service_node, update_column_element);
+
+    if (HasTokens() && NodeDataClassifier::IsComma(PeekToken())) {
+      auto next_token = NextToken();
+      ValidateHasTokens(format("Missing update column statement after comma at line {}",
+                               next_token->line));
+      ValidateIsWord(PeekToken());
+    } else {
+      break;
+    }
+  }
+
+  if (HasTokens() && NodeDataTypeClassifier::IsWord(PeekToken())) {
+    auto where_condition = ParseWhereStatement();
+    ASTUtils::Link(service_node, where_condition);
+  }
+
+  return service_node;
+}
 NodePtr<INode> Parser::ParseDeleteStatement() {
   return ASTUtils::CreateServiceNode(StmtType::kDeleteStmt);
-}
-NodePtr<INode> Parser::ParseUpdateStatement() {
-  return ASTUtils::CreateServiceNode(StmtType::kUpdateStmt);
 }
 
 NodePtr<INode> Parser::ParseInsertValuesList() {
@@ -151,6 +187,23 @@ NodePtr<INode> Parser::ParseInsertValuesList() {
   }
 
   return values_list;
+}
+NodePtr<INode> Parser::ParseUpdateColumnElement() {
+  auto service_node = ASTUtils::CreateServiceNode(StmtType::kUpdateColumn);
+
+  auto column_name = ParseColumnName();
+
+  ValidateHasTokens(format("Missing assignment operator at line {}", column_name->line));
+  auto assignment_operator = NextToken();
+  ValidateIsAssignmentOperator(assignment_operator);
+  ASTUtils::Link(service_node, assignment_operator);
+  ASTUtils::Link(assignment_operator, column_name);
+
+  ValidateHasTokens(format("Missing value for column at line {}", assignment_operator->line));
+  auto expression_or_null = ParseExpressionOrNull();
+  ASTUtils::Link(assignment_operator, expression_or_null);
+
+  return service_node;
 }
 
 } // scc::parser

--- a/src/parser/dml/dml_statements.cpp
+++ b/src/parser/dml/dml_statements.cpp
@@ -144,7 +144,29 @@ NodePtr<INode> Parser::ParseUpdateStatement() {
   return service_node;
 }
 NodePtr<INode> Parser::ParseDeleteStatement() {
-  return ASTUtils::CreateServiceNode(StmtType::kDeleteStmt);
+  auto service_node = ASTUtils::CreateServiceNode(StmtType::kDeleteStmt);
+
+  auto peeked_token = PeekToken();
+  ValidateIsWord(peeked_token);
+  std::string next_word = ASTUtils::CastToNodeType<StringNode>(peeked_token)->data;
+  try {
+    StmtType from_kw(next_word);
+    if (from_kw != StmtType::kFromKW) {
+      throw parsing_error(format("Expected \'FROM\' keyword at line {}", peeked_token->line));
+    }
+    NextToken();
+  } catch (const std::invalid_argument& ignored) {}
+
+  ValidateHasTokens(format("Missing table name at line {}", peeked_token->line));
+  auto table_name = ParseTableName();
+  ASTUtils::Link(service_node, table_name);
+
+  ValidateHasTokens(format("Incorrect \'DELETE\' statement: expected condition at line {}",
+                           table_name->line));
+  auto where_condition = ParseWhereStatement();
+  ASTUtils::Link(service_node, where_condition);
+
+  return service_node;
 }
 
 NodePtr<INode> Parser::ParseInsertValuesList() {

--- a/src/parser/dml/math_expressions.cpp
+++ b/src/parser/dml/math_expressions.cpp
@@ -23,95 +23,106 @@ using NodePtr = std::shared_ptr<NodeType>;
  * @endcode
  */
 NodePtr<INode> Parser::ParseMathExpression() {
-  NodePtr<INode> math_expression = ParseMathSum();
+  auto math_expression = ASTUtils::CreateServiceNode(StmtType::kMathExpression);
+
+  auto sum = ParseMathSum();
+  ASTUtils::Link(math_expression, sum);
+
   return math_expression;
 }
 NodePtr<INode> Parser::ParseMathSum() {
+  auto sum = ASTUtils::CreateServiceNode(StmtType::kSum);
+
   NodePtr<INode> lhs_product = ParseMathProduct();
+  ASTUtils::Link(sum, lhs_product);
 
   if (HasTokens() && NodeDataTypeClassifier::IsOperator(PeekToken())) {
-    NodePtr<INode> operator_node = PeekToken();
+    auto operator_node = PeekToken();
     std::string operator_str = ASTUtils::CastToNodeType<StringNode>(operator_node)->data;
     if (operator_str == "+" || operator_str == "-") {
       NextToken();
-      ASTUtils::Link(operator_node, lhs_product);
+      ASTUtils::Link(sum, operator_node);
 
       ValidateHasTokens(format("Incorrect math expression at line {}"
                                ": missing second operand for \'{}\' binary operator",
                                operator_node->line, operator_str));
       NodePtr<INode> rhs_product = ParseMathProduct();
-      ASTUtils::Link(operator_node, rhs_product);
-      return operator_node;
+      ASTUtils::Link(sum, rhs_product);
     }
   }
 
-  return lhs_product;
+  return sum;
 }
 NodePtr<INode> Parser::ParseMathProduct() {
+  auto product = ASTUtils::CreateServiceNode(StmtType::kProduct);
+
   NodePtr<INode> lhs_power = ParseMathPower();
+  ASTUtils::Link(product, lhs_power);
 
   if (HasTokens() && NodeDataTypeClassifier::IsOperator(PeekToken())) {
     NodePtr<INode> operator_node = PeekToken();
     std::string operator_str = ASTUtils::CastToNodeType<StringNode>(operator_node)->data;
     if (operator_str == "*" || operator_str == "/") {
       NextToken();
-      ASTUtils::Link(operator_node, lhs_power);
+      ASTUtils::Link(product, operator_node);
 
       ValidateHasTokens(format("Incorrect math expression at line {}"
                                ": missing second operand for \'\' binary operator",
                                operator_node->line, operator_str));
       NodePtr<INode> rhs_power = ParseMathPower();
-      ASTUtils::Link(operator_node, rhs_power);
-      return operator_node;
+      ASTUtils::Link(product, rhs_power);
     }
   }
 
-  return lhs_power;
+  return product;
 }
 NodePtr<INode> Parser::ParseMathPower() {
+  auto power = ASTUtils::CreateServiceNode(StmtType::kPower);
+
   NodePtr<INode> value = ParseMathValue();
+  ASTUtils::Link(power, value);
 
   if (HasTokens() && NodeDataTypeClassifier::IsOperator(PeekToken())) {
     NodePtr<INode> operator_node = PeekToken();
     std::string operator_str = ASTUtils::CastToNodeType<StringNode>(operator_node)->data;
     if (operator_str == "^") {
       NextToken();
-      ASTUtils::Link(operator_node, value);
+      ASTUtils::Link(power, operator_node);
 
       ValidateHasTokens(format("Incorrect math expression at line {}"
                                ": missing second operand for \'{}\' binary operator",
                                operator_node->line, operator_str));
-      NodePtr<INode> power = ParseMathPower();
-      ASTUtils::Link(operator_node, power);
-      return operator_node;
+      NodePtr<INode> next_power = ParseMathPower();
+      ASTUtils::Link(power, next_power);
     }
   }
 
-  return value;
+  return power;
 }
 NodePtr<INode> Parser::ParseMathValue() {
-  auto peeked_token = PeekToken();
+  auto value = ASTUtils::CreateServiceNode(StmtType::kValue);
 
+  auto peeked_token = PeekToken();
   if (NodeDataTypeClassifier::IsNumber(peeked_token)) {
     NodePtr<INode> number = NextToken();
-    return number;
+    ASTUtils::Link(value, number);
+    return value;
   }
 
   std::string msg_prefix = "Incorrect math expression at line ";
-
   if (NodeDataClassifier::IsOpeningRoundBracket(peeked_token)) {
     auto next_token = NextToken();
-
     ValidateHasTokens(format("{} {}: incorrect parenthesis sequence \'(\'",
                              msg_prefix, next_token->line));
     NodePtr<INode> math_expression = ParseMathExpression();
+    ASTUtils::Link(value, math_expression);
 
     ValidateHasTokens(format("{} {}: missing closing parenthesis",
                              msg_prefix, math_expression->line));
     next_token = NextToken();
     ValidateIsClosingRoundBracket(next_token);
 
-    return math_expression;
+    return value;
   }
 
   throw parsing_error(format("{} {}: expected number or math expression in parentheses",

--- a/src/translator/cypher/clauses/create.cpp
+++ b/src/translator/cypher/clauses/create.cpp
@@ -13,7 +13,8 @@ std::string CreateNodeClauseBuilder::Build(const Node& node) {
 }
 
 std::string CreateConstraintClauseBuilder::Build(const std::string& constraint_name,
-                                                 const Node& node, const Property& property,
+                                                 const std::string& label,
+                                                 const std::string& property_name,
                                                  ConstraintType type) {
   if (type == ConstraintType::kNone) {
     std::string msg = format("Could not build \'CREATE CONSTRAINT\' clause "
@@ -24,12 +25,12 @@ std::string CreateConstraintClauseBuilder::Build(const std::string& constraint_n
   std::stringstream ss;
   ss << "CREATE CONSTRAINT " << constraint_name << "\n";
 
-  std::string variable_name = node.variable.empty() ? std::string(kDefaultVar) : node.variable;
-  ss << "FOR (" << variable_name;
-  ss << ":" << node.label;
+  std::string var = std::string(kDefaultVar);
+  ss << "FOR (" << var;
+  ss << ":" << label;
   ss << ")" << "\n";
 
-  ss << "REQUIRE (" << variable_name << "." << property.name << ")";
+  ss << "REQUIRE (" << var << "." << property_name << ")";
   ss << " IS " << common::UpperCase(type.ToString());
 
   return ss.str();
@@ -39,6 +40,18 @@ std::string CreateRelationshipClauseBuilder::Build(const Relationship& relations
   std::stringstream ss;
   ss << "MATCH " << relationship.start.ToString() << ", " << relationship.end.ToString() << "\n";
   ss << "CREATE " << relationship.ToString();
+  return ss.str();
+}
+std::string CreateRelationshipClauseBuilder::Build(const std::string& start,
+                                                   const std::string& start_prop,
+                                                   const std::string& end,
+                                                   const std::string& end_prop,
+                                                   const std::string& relationship_type) {
+  std::stringstream ss;
+  std::string varA = "a", varB = "b";
+  ss << format("MATCH ({}:{}), ({}:{})\n", varA, start, varB, end);
+  ss << format("WHERE {}.{} = {}.{}\n", varA, start_prop, varB, end_prop);
+  ss << format("CREATE ({})-[:{}]->({})", varA, relationship_type, varB);
   return ss.str();
 }
 

--- a/src/translator/cypher/clauses/set.cpp
+++ b/src/translator/cypher/clauses/set.cpp
@@ -2,10 +2,16 @@
 
 namespace scc::translator::cypher {
 
-std::string SetPropertyClauseBuilder::Build(const Node& node, const Property& property) {
+std::string SetPropertyClauseBuilder::Build(const std::string& label, const Property& property) {
   std::stringstream ss;
+  Node node(label, "n");
   ss << "MATCH " << node.ToString() << "\n";
-  ss << "SET " << node.variable << "." << property.name << " = " << property.value;
+  ss << "SET " << node.variable << "." << property.name << " = ";
+  if (property.type == PropertyType::kString) {
+    ss << "\"" << property.value << "\"";
+  } else {
+    ss << property.value;
+  }
 
   return ss.str();
 }

--- a/src/translator/cypher/graph/CMakeLists.txt
+++ b/src/translator/cypher/graph/CMakeLists.txt
@@ -8,4 +8,5 @@ target_sources(scc_translator_cypher_graph PRIVATE
 )
 target_link_libraries(scc_translator_cypher_graph PRIVATE
         scc_include
+        scc_common
 )

--- a/src/translator/cypher/graph/property.cpp
+++ b/src/translator/cypher/graph/property.cpp
@@ -6,7 +6,14 @@ Property::Property(std::string  name, std::string value, PropertyType type)
     : name(std::move(name)), type(type), value(std::move(value)) {}
 
 std::string Property::ToString() const {
-  return name + ": " + value;
+  std::stringstream ss;
+  ss << name << ": ";
+  if (type == PropertyType::kString)  {
+    ss << "\"" << value << "\"";
+  } else {
+    ss << value;
+  }
+  return ss.str();
 }
 
 bool operator==(const Property& lhs, const Property& rhs) {

--- a/src/translator/cypher/graph/property_types.cpp
+++ b/src/translator/cypher/graph/property_types.cpp
@@ -8,7 +8,7 @@ PropertyType::PropertyType(Value value) {
   this->value_ = value;
 }
 PropertyType::PropertyType(const std::string_view& str_type) {
-  std::string type = scc::common::LowerCase(std::string(str_type));
+  std::string type = scc::common::UpperCase(std::string(str_type));
   if (type == kPT_Unknown)
     this->value_ = kUnknown;
   else if (type == kPT_Boolean)

--- a/src/translator/cypher/graph/property_types.cpp
+++ b/src/translator/cypher/graph/property_types.cpp
@@ -3,7 +3,7 @@
 namespace scc::translator::cypher {
 
 PropertyType::PropertyType(Value value) {
-  if (value > kString)
+  if (value > kNull)
     throw std::invalid_argument("Incorrect value for Cypher Property Type");
   this->value_ = value;
 }
@@ -19,6 +19,8 @@ PropertyType::PropertyType(const std::string_view& str_type) {
     this->value_ = kInteger;
   else if (type == kPT_String)
     this->value_ = kString;
+  else if (type == kPT_Null)
+    this->value_ = kNull;
   else
     throw std::invalid_argument("No Cypher Property Type for '" + std::string(str_type) + "'");
 }
@@ -35,6 +37,8 @@ std::string PropertyType::ToString() const {
       return std::string(kPT_Integer);
     case kString:
       return std::string(kPT_String);
+    case kNull:
+      return std::string(kPT_Null);
   }
 }
 

--- a/src/translator/dml/CMakeLists.txt
+++ b/src/translator/dml/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(scc_translator_dml STATIC)
 target_sources(scc_translator_dml PRIVATE
+        conditions.cpp
         dml_statements.cpp
+        math_expressions.cpp
 )
 target_link_libraries(scc_translator_dml PRIVATE
         scc_include

--- a/src/translator/dml/conditions.cpp
+++ b/src/translator/dml/conditions.cpp
@@ -1,0 +1,62 @@
+#include "SCC/translator/translator.h"
+
+namespace scc::translator {
+
+using namespace ast;
+using namespace ast::common;
+
+using std::format;
+using cypher::PropertyType;
+
+template<typename ASTNodeType,
+    typename std::enable_if<std::is_base_of<INode, ASTNodeType>::value>::type* = nullptr>
+using ASTNodePtr = std::shared_ptr<ASTNodeType>;
+template<typename T, typename U>
+using Pair = std::pair<T, U>;
+
+Pair<PropertyType, std::string>
+Translator::TranslateExpression(const ASTNodePtr<INode>& expr) const {
+  auto value_node = expr->Child(0);
+
+  if (IsCorrectStmtType(value_node, StmtType::kName)) {
+    // TODO: property can not be got from node with StmtType::kName stmt type, but expression can.
+  }
+
+  if (HasChildren(value_node, 2)) {
+    // TODO: property can not be '!expr', but expression can.
+  }
+
+  if (IsCorrectStmtType(value_node, StmtType::kExpression)) {
+    return TranslateExpression(value_node);
+  }
+
+  if (value_node->data_type == DataType::kString) {
+    auto value = ASTUtils::CastToNodeType<StringNode>(value_node)->data;
+    return {PropertyType::kString, value};
+  }
+
+  if (IsCorrectStmtType(value_node, StmtType::kMathExpression)) {
+    throw translation_error("Math expressions are not supported yet");
+  }
+
+  switch (value_node->data_type) {
+    case DataType::kInt: {
+      auto value = ASTUtils::CastToNodeType<IntNumNode>(value_node)->data;
+      return {PropertyType::kInteger, std::to_string(value)};
+    }
+    case DataType::kFloat: {
+      auto value = ASTUtils::CastToNodeType<FloatNumNode>(value_node)->data;
+      return {PropertyType::kFloat, std::to_string(value)};
+    }
+    case DataType::kWord: {
+      auto value = scc::common::LowerCase(ASTUtils::CastToNodeType<StringNode>(value_node)->data);
+      if (value == "true" || value == "false") {
+        return {PropertyType::kBoolean, value};
+      }
+    }
+    default:
+      throw translation_error("Can not translate expression: unsupported value");
+  }
+}
+
+} // scc::translator

--- a/src/translator/dml/dml_statements.cpp
+++ b/src/translator/dml/dml_statements.cpp
@@ -3,7 +3,7 @@
 namespace scc::translator {
 
 using namespace ast;
-using namespace cypher;
+using namespace scc::translator::cypher;
 
 using std::format;
 
@@ -81,18 +81,69 @@ void Translator::TranslateInsertStatement(const NodePtr<INode>& stmt) {
 
   Node node(table_name, properties);
   if (schema_node.Validate(node)) {
-    WriteCypherQuery(cypher::CreateNodeClauseBuilder::Build(node));
+    WriteCypherQuery(CreateNodeClauseBuilder::Build(node));
   } else {
     std::string msg = format("Node {} does not correspond to node from the schema:\n{}",
                              node.ToString(), schema_node.ToJsonString());
     throw translation_error(msg);
   }
 }
+void Translator::TranslateUpdateStatement(const NodePtr<INode>& stmt) {
+  auto table_name_node = stmt->Child(0);
+  ValidateHasChildren(table_name_node);
+  std::string table_name = GetName(table_name_node);
+
+  const auto& schema_node = schema_.FindNodeOrThrow(table_name);
+  std::vector<Property> properties;
+
+  std::string msg_suffix = "in \'UPDATE\' statement";
+
+  for (unsigned i = 1; i < stmt->ChildrenCount(); ++i) {
+    auto update_column_node = stmt->Child(i);
+    IsCorrectStmtType(update_column_node, StmtType::kUpdateColumn);
+    ValidateHasChildren(update_column_node, 2);
+
+    Property property;
+
+    auto column_name_node = update_column_node->Child(0);
+    ValidateIsCorrectStmtType(column_name_node, StmtType::kName);
+    property.name = GetName(column_name_node);
+
+    auto expression_or_null = update_column_node->Child(1);
+    if (IsCorrectStmtType(expression_or_null, StmtType::kNullValue)) {
+      property.type = PropertyType::kNull;
+      property.value = property.type.ToString();
+    } else if (IsCorrectStmtType(expression_or_null, StmtType::kExpression)) {
+      auto [type, value] = TranslateExpression(expression_or_null);
+      property.type  = type;
+      property.value = value;
+    } else {
+      std::string msg = format("Expected \'NULL\' or expression value {}", msg_suffix);
+      throw translation_error(msg);
+    }
+
+    properties.push_back(property);
+  }
+
+  for (const auto& property : properties) {
+    try {
+      const auto& schema_property = schema_node.FindPropertyOrThrow(property.name);
+      if (!schema_property.Validate(property)) {
+        std::string msg = format("Property {} does not correspond to property from the schema:\n{}",
+                                 property.name, schema_property.ToJsonString());
+        throw translation_error(msg);
+      } else {
+        WriteCypherQuery(SetPropertyClauseBuilder::Build(table_name, property));
+      }
+    } catch (const std::runtime_error& error) {
+      std::string msg = format("Property {} does not exist in the node \'{}\' from the schema",
+                               property.name, table_name);
+      throw translation_error(msg);
+    }
+  }
+}
 void Translator::TranslateDeleteStatement(const NodePtr<INode>& stmt) {
   ValidateHasChildren(stmt, 1, "Empty \'DELETE\' statement");
-}
-void Translator::TranslateUpdateStatement(const NodePtr<INode>& stmt) {
-  ValidateHasChildren(stmt, 1, "Empty \'UPDATE\' statement");
 }
 
 } // scc::translator

--- a/src/translator/dml/dml_statements.cpp
+++ b/src/translator/dml/dml_statements.cpp
@@ -3,6 +3,7 @@
 namespace scc::translator {
 
 using namespace ast;
+using namespace cypher;
 
 using std::format;
 
@@ -27,14 +28,71 @@ void Translator::TranslateDMLStatement(const NodePtr<INode>& dml_statement) {
   }
 }
 
-void Translator::TranslateInsertStatement(const NodePtr<INode>& insert_stmt) {
-  ValidateHasChildren(insert_stmt, 1, "Empty \'INSERT\' statement");
+void Translator::TranslateInsertStatement(const NodePtr<INode>& stmt) {
+  auto table_name_node = stmt->Child(0);
+  ValidateHasChildren(table_name_node);
+  std::string table_name = GetName(table_name_node);
+
+  const auto& schema_node = schema_.FindNodeOrThrow(table_name);
+  unsigned properties_count = schema_node.PropertyCount();
+
+  std::string msg_suffix = "in \'INSERT\' statement";
+
+  std::vector<Property> properties(properties_count);
+  unsigned child_count = 2;
+  ValidateHasChildren(stmt, child_count, format(R"(Expected {} values for '{}' table {})",
+                                      properties_count, table_name, msg_suffix));
+  auto next_child = stmt->Child(1);
+  if (IsCorrectStmtType(next_child, StmtType::kName)) {
+    child_count += properties_count;
+    ValidateHasChildren(stmt, child_count,
+                        format(R"(Expected {} column names for '{}' table {})",
+                               properties_count, table_name, msg_suffix));
+    for (unsigned i = 1; i < child_count - 1; ++i) {
+      auto column_name_node = stmt->Child(i);
+      ValidateIsCorrectStmtType(column_name_node, StmtType::kName);
+      ValidateHasChildren(column_name_node);
+      properties[i - 1].name = GetName(column_name_node);
+    }
+  }
+
+  ValidateHasChildren(stmt, child_count);
+  auto values = stmt->Child(child_count - 1);
+  ValidateIsCorrectStmtType(values, StmtType::kValuesKW);
+  for (unsigned i = 0; i < properties_count; ++i) {
+    auto expression_or_null = values->Child(i);
+    auto& property = properties[i];
+    if (property.name.empty()) {
+      property.name = schema_node.properties[i].name;
+    }
+
+    if (IsCorrectStmtType(expression_or_null, StmtType::kNullValue)) {
+      property.type = PropertyType::kNull;
+      property.value = property.type.ToString();
+    } else if (IsCorrectStmtType(expression_or_null, StmtType::kExpression)) {
+      auto [type, value] = TranslateExpression(expression_or_null);
+      property.type  = type;
+      property.value = value;
+    } else {
+      std::string msg = format("Expected \'NULL\' or expression value {}", msg_suffix);
+      throw translation_error(msg);
+    }
+  }
+
+  Node node(table_name, properties);
+  if (schema_node.Validate(node)) {
+    WriteCypherQuery(cypher::CreateNodeClauseBuilder::Build(node));
+  } else {
+    std::string msg = format("Node {} does not correspond to node from the schema:\n{}",
+                             node.ToString(), schema_node.ToJsonString());
+    throw translation_error(msg);
+  }
 }
-void Translator::TranslateDeleteStatement(const NodePtr<INode>& delete_stmt) {
-  ValidateHasChildren(delete_stmt, 1, "Empty \'DELETE\' statement");
+void Translator::TranslateDeleteStatement(const NodePtr<INode>& stmt) {
+  ValidateHasChildren(stmt, 1, "Empty \'DELETE\' statement");
 }
-void Translator::TranslateUpdateStatement(const NodePtr<INode>& update_stmt) {
-  ValidateHasChildren(update_stmt, 1, "Empty \'UPDATE\' statement");
+void Translator::TranslateUpdateStatement(const NodePtr<INode>& stmt) {
+  ValidateHasChildren(stmt, 1, "Empty \'UPDATE\' statement");
 }
 
 } // scc::translator

--- a/src/translator/dml/math_expressions.cpp
+++ b/src/translator/dml/math_expressions.cpp
@@ -1,0 +1,115 @@
+#include "SCC/translator/translator.h"
+
+namespace scc::translator {
+
+using namespace ast;
+using namespace ast::common;
+
+using std::format;
+
+template<typename ASTNodeType,
+    typename std::enable_if<std::is_base_of<INode, ASTNodeType>::value>::type* = nullptr>
+using ASTNodePtr = std::shared_ptr<ASTNodeType>;
+
+std::string Translator::TranslateMathExpression(const ASTNodePtr<INode>& expr) const {
+  std::stringstream ss;
+
+  auto sum_node = expr->Child(0);
+  ValidateIsCorrectStmtType(sum_node, StmtType::kSum);
+  ValidateHasChildren(sum_node);
+  auto sum = TranslateMathSum(sum_node);
+  ss << sum;
+
+  return ss.str();
+}
+std::string Translator::TranslateMathSum(const ASTNodePtr<INode>& sum) const {
+  std::stringstream ss;
+
+  auto left_product_node = sum->Child(0);
+  ValidateIsCorrectStmtType(left_product_node, StmtType::kProduct);
+  ValidateHasChildren(left_product_node);
+  auto left_product = TranslateMathProduct(left_product_node);
+  ss << left_product;
+
+  if (HasChildren(sum, 2)) {
+    ValidateHasChildren(sum, 3);
+    auto operator_str = ASTUtils::CastToNodeType<StringNode>(sum->Child(1))->data;
+
+    auto right_product_node = sum->Child(2);
+    ValidateIsCorrectStmtType(right_product_node, StmtType::kProduct);
+    ValidateHasChildren(right_product_node);
+    auto right_product = TranslateMathProduct(right_product_node);
+
+    ss << format(" {} {}", operator_str, right_product);
+  }
+
+  return ss.str();
+}
+std::string Translator::TranslateMathProduct(const ASTNodePtr<INode>& product) const {
+  std::stringstream ss;
+
+  auto left_power_node = product->Child(0);
+  ValidateIsCorrectStmtType(left_power_node, StmtType::kPower);
+  ValidateHasChildren(left_power_node);
+  auto left_power = TranslateMathPower(left_power_node);
+  ss << left_power;
+
+  if (HasChildren(product, 2)) {
+    ValidateHasChildren(product, 3);
+    auto operator_str = ASTUtils::CastToNodeType<StringNode>(product->Child(1))->data;
+
+    auto right_power_node = product->Child(2);
+    ValidateIsCorrectStmtType(right_power_node, StmtType::kPower);
+    ValidateHasChildren(right_power_node);
+    auto right_power = TranslateMathPower(right_power_node);
+
+    ss << format(" {} {}", operator_str, right_power);
+  }
+
+  return ss.str();
+}
+std::string Translator::TranslateMathPower(const ASTNodePtr<INode>& power) const {
+  std::stringstream ss;
+
+  auto value_node = power->Child(0);
+  ValidateIsCorrectStmtType(value_node, StmtType::kValue);
+  ValidateHasChildren(value_node);
+  auto value = TranslateMathValue(value_node);
+  ss << value;
+
+  if (HasChildren(power, 2)) {
+    ValidateHasChildren(power, 3);
+    auto operator_str = ASTUtils::CastToNodeType<StringNode>(power->Child(1))->data;
+
+    auto next_power_node = power->Child(2);
+    ValidateIsCorrectStmtType(next_power_node, StmtType::kPower);
+    ValidateHasChildren(next_power_node);
+    auto next_power = TranslateMathPower(next_power_node);
+
+    ss << format("{}{}", operator_str, next_power);
+  }
+
+  return ss.str();
+}
+std::string Translator::TranslateMathValue(const ASTNodePtr<INode>& value) const {
+  std::stringstream ss;
+
+  auto node = value->Child(0);
+  if (IsCorrectStmtType(node, StmtType::kMathExpression)) {
+    ValidateHasChildren(node);
+    auto math_expression = TranslateMathExpression(node);
+    return format("({})", math_expression);
+  } else {
+    switch (node->data_type) {
+      case DataType::kInt:
+        return std::to_string(ASTUtils::CastToNodeType<IntNumNode>(node)->data);
+      case DataType::kFloat:
+        return std::to_string(ASTUtils::CastToNodeType<FloatNumNode>(node)->data);
+      default:
+        std::string msg = format("Unknown value data type: {}", node->data_type.ToString());
+        throw translation_error(msg);
+    }
+  }
+}
+
+} // scc::translator

--- a/src/translator/schema/node.cpp
+++ b/src/translator/schema/node.cpp
@@ -3,6 +3,7 @@
 namespace scc::translator::schema {
 
 using std::format;
+using nlohmann::json;
 
 Node::Node(std::string label)
     : label(std::move(label)) {}
@@ -62,6 +63,12 @@ bool Node::Validate(const cypher::Node& node) const {
   }
 
   return true;
+}
+
+std::string Node::ToJsonString(int indent, char indent_char) const {
+  json node_json;
+  to_json(node_json, *this);
+  return node_json.dump(indent, indent_char);
 }
 
 bool Node::operator==(const Node& other) const {

--- a/src/translator/schema/node.cpp
+++ b/src/translator/schema/node.cpp
@@ -22,6 +22,16 @@ bool Node::HasProperty(const std::string& name) const {
   auto predicate = [name](const Property& property) { return property.name == name; };
   return std::any_of(properties.begin(), properties.end(), predicate);
 }
+const Property& Node::FindPropertyOrThrow(const std::string& name) const {
+  auto predicate = [name](const Property& property) { return property.name == name; };
+  auto propIt = std::find_if(properties.begin(), properties.end(), predicate);
+  if (propIt == properties.end())  {
+    std::string msg = format(R"(Property with name '{}' does not exist in node '{}')",
+                             name, label);
+    throw std::runtime_error(msg);
+  }
+  return *propIt;
+}
 int Node::PropertyIndex(const std::string& name) const {
   auto predicate = [name](const Property& property) { return property.name == name; };
   auto it = std::find_if(properties.begin(), properties.end(), predicate);
@@ -32,6 +42,26 @@ int Node::PropertyIndex(const std::string& name) const {
 }
 unsigned Node::PropertyCount() const {
   return properties.size();
+}
+
+bool Node::Validate(const cypher::Node& node) const {
+  if (label != node.label) {
+    return false;
+  }
+
+  if (PropertyCount() != node.PropertyCount())  {
+    return false;
+  }
+
+  for (unsigned i = 0; i < PropertyCount(); ++i) {
+    const auto& schema_property = properties[i];
+    const auto& property = node.properties[i];
+    if (!schema_property.Validate(property)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 bool Node::operator==(const Node& other) const {

--- a/src/translator/schema/property.cpp
+++ b/src/translator/schema/property.cpp
@@ -27,6 +27,9 @@ bool Property::MustBeUnique() const {
 bool Property::MustBeNotNull() const {
   return HasConstraintType(ConstraintType::kExistence);
 }
+const std::vector<PropertyConstraint>& Property::Constraints() const {
+  return constraints;
+}
 
 bool Property::operator==(const Property& other) const {
   return name == other.name

--- a/src/translator/schema/property.cpp
+++ b/src/translator/schema/property.cpp
@@ -31,6 +31,22 @@ const std::vector<PropertyConstraint>& Property::Constraints() const {
   return constraints;
 }
 
+bool Property::Validate(const cypher::Property& property) const {
+  if (name != property.name) {
+    return false;
+  }
+
+  if (property.type == PropertyType::kNull) {
+    return true;
+  }
+
+  if (type != property.type) {
+    return false;
+  }
+
+  return true;
+}
+
 bool Property::operator==(const Property& other) const {
   return name == other.name
       && type == other.type

--- a/src/translator/schema/property.cpp
+++ b/src/translator/schema/property.cpp
@@ -2,6 +2,7 @@
 
 namespace scc::translator::schema {
 
+using nlohmann::json;
 using cypher::ConstraintType;
 using cypher::PropertyType;
 
@@ -45,6 +46,12 @@ bool Property::Validate(const cypher::Property& property) const {
   }
 
   return true;
+}
+
+std::string Property::ToJsonString(int indent, char indent_char) const {
+  json property_json;
+  to_json(property_json, *this);
+  return property_json.dump(indent, indent_char);
 }
 
 bool Property::operator==(const Property& other) const {

--- a/src/translator/schema/relationship.cpp
+++ b/src/translator/schema/relationship.cpp
@@ -25,6 +25,9 @@ void Relationship::RemoveConditionByEPI(int epi) {
     return condition.epi == epi;
   });
 }
+const std::vector<ApplyCondition>& Relationship::Conditions() const {
+  return conditions;
+}
 
 bool Relationship::operator==(const Relationship& other) const {
   if (type != other.type

--- a/src/translator/schema/schema.cpp
+++ b/src/translator/schema/schema.cpp
@@ -91,6 +91,12 @@ Node& Schema::GetNodeOrThrow(const std::string& label) {
   }
   return node_res.value().get();
 }
+const std::vector<Node>& Schema::Nodes() const {
+  return nodes;
+}
+const std::vector<Relationship>& Schema::Relationships() const {
+  return relationships;
+}
 
 void Schema::RemoveNode(const std::string& label) {
   auto nodeIt = std::find_if(nodes.begin(), nodes.end(),
@@ -159,6 +165,21 @@ void Schema::RemovePropertyIdxFromConditions(const std::string& label, int pi) {
   }
 }
 
+bool operator==(const Schema& lhs, const Schema& rhs) {
+  if (lhs.database_name != rhs.database_name) {
+    return false;
+  }
+
+  if (lhs.Nodes() != rhs.Nodes()) {
+    return false;
+  }
+
+  if (lhs.Relationships() != rhs.Relationships()) {
+    return false;
+  }
+
+  return true;
+}
 std::ifstream& operator>>(std::ifstream& is, Schema& schema) {
   json json_data = json::parse(is);
   from_json(json_data, schema);

--- a/src/translator/schema/schema.cpp
+++ b/src/translator/schema/schema.cpp
@@ -159,4 +159,10 @@ void Schema::RemovePropertyIdxFromConditions(const std::string& label, int pi) {
   }
 }
 
+std::ifstream& operator>>(std::ifstream& is, Schema& schema) {
+  json json_data = json::parse(is);
+  from_json(json_data, schema);
+  return is;
+}
+
 } // scc::translator::cypher

--- a/src/translator/translator.cpp
+++ b/src/translator/translator.cpp
@@ -46,6 +46,39 @@ void Translator::Translate() {
     out_ << schema_.ToJsonString() << std::endl;
     LOGI << "Serialized Neo4j schema saved at " << schema_path_.string();
   }
+
+  if (translate_data_) {
+    for (const auto& node : schema_.Nodes()) {
+      for (const auto& property : node.properties) {
+        for (const auto& constraint : property.Constraints()) {
+          WriteCypherQuery(cypher::CreateConstraintClauseBuilder::Build(
+              constraint.name,
+              node.label,
+              property.name,
+              constraint.type
+          ));
+        }
+      }
+      FinishCypherQueriesGroup();
+    }
+
+    for (const auto& relationship : schema_.Relationships()) {
+      const auto& start_node = schema_.FindNodeOrThrow(relationship.start);
+      const auto& end_node = schema_.FindNodeOrThrow(relationship.end);
+      for (const auto& condition : relationship.Conditions()) {
+        const auto& start_prop = start_node.properties.at(condition.spi);
+        const auto& end_prop = end_node.properties.at(condition.epi);
+        WriteCypherQuery(cypher::CreateRelationshipClauseBuilder::Build(
+            start_node.label,
+            start_prop.name,
+            end_node.label,
+            end_prop.name,
+            relationship.type
+        ));
+      }
+      FinishCypherQueriesGroup();
+    }
+  }
 }
 
 void Translator::WriteCypherQuery(const std::string& query) {

--- a/src/translator/translator.cpp
+++ b/src/translator/translator.cpp
@@ -41,9 +41,11 @@ void Translator::Translate() {
   }
   LOGI << "Translation is ended";
 
-  LOGI << "Serializing Neo4j schema to json...";
-  out_ << schema_.ToJsonString() << std::endl;
-  LOGI << "Serialized Neo4j schema saved at " << schema_path_.string();
+  if (translate_schema_) {
+    LOGI << "Serializing Neo4j schema to json...";
+    out_ << schema_.ToJsonString() << std::endl;
+    LOGI << "Serialized Neo4j schema saved at " << schema_path_.string();
+  }
 }
 
 void Translator::WriteCypherQuery(const std::string& query) {

--- a/src/translator/translator.cpp
+++ b/src/translator/translator.cpp
@@ -5,27 +5,32 @@ namespace scc::translator {
 using namespace ast;
 namespace fs = std::filesystem;
 
+using std::format;
+
 template<typename NodeType,
     typename std::enable_if<std::is_base_of<INode, NodeType>::value>::type* = nullptr>
 using NodePtr = std::shared_ptr<NodeType>;
 
-Translator::Translator(NodePtr<INode> ast, const fs::path& out_path, bool translate_schema)
-    : ast_(std::move(ast)), translate_schema_(translate_schema), schema_path_(out_path) {}
+Translator::Translator(std::shared_ptr<ast::INode> ast, const std::filesystem::path& out_path)
+    : ast_(std::move(ast)), translate_schema_(true), out_(out_path) {}
+Translator::Translator(std::shared_ptr<ast::INode> ast, std::filesystem::path graph_schema_path,
+                       const std::filesystem::path& out_path)
+    : ast_(std::move(ast)), translate_data_(true), schema_path_(std::move(graph_schema_path)),
+      out_(out_path) {
+  try {
+    scc::common::ValidateFileExists(schema_path_);
+    std::ifstream(schema_path_) >> schema_;
+  } catch (const std::runtime_error& e) {
+    std::string msg = format("Could not load Graph Schema: {}", e.what());
+    throw translation_error(msg);
+  }
+}
 
 void Translator::Translate() {
   LOGI << "Translation is started";
   if (ast_ == nullptr || !HasChildren(ast_)) {
     LOGI << "Translation is ended. Nothing to translate";
     return;
-  }
-
-  if (!translate_schema_) {
-    LOGW << "Currently only translation of schema migration queries is supported."
-         << " Use --translate-schema flag to translate schema";
-    return;
-  } else {
-    schema_path_.replace_extension(".json");
-    out_.open(schema_path_);
   }
 
   ValidateIsCorrectStmtType(ast_, StmtType::kProgram);
@@ -70,7 +75,7 @@ void Translator::TranslateQuery(const NodePtr<INode>& query) {
                                      statement_type->stmt_type.ToString()));
   }
 
-  if (statement_type->stmt_type != StmtType::kDdlStmt) {
+  if (!translate_schema_) {
     FinishCypherQueriesGroup();
   }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ set(DIRS
         config
         fixtures
         lexer
+        translator
 )
 foreach(DIR ${DIRS})
     add_subdirectory(${DIR})

--- a/test/config/scc_args_test.cpp
+++ b/test/config/scc_args_test.cpp
@@ -37,9 +37,34 @@ TEST_F(SCCArgsBaseTests, GetVersionShortOptionTest) {
   EXPECT_EXIT(ParseArgsWrapper(), ExitedWithCode(EXIT_SUCCESS), ""); // TODO: add regex.
 }
 
+TEST_F(SCCArgsBaseTests, TranslateSchemaOptionTest) {
+  AddArg("--translate-schema");
+
+  EXPECT_NO_THROW(ParseArgsWrapper());
+}
+
+TEST_F(SCCArgsBaseTests, TranslateDataOptionTest) {
+  AddArg("--translate-data");
+
+  EXPECT_NO_THROW(ParseArgsWrapper());
+}
+
+TEST_F(SCCArgsBaseTests, SQLSchemaArgumentTest) {
+  const std::string sql_schema_file = sql_schema_path;
+  AddArg("--sql-schema", sql_schema_file);
+
+  EXPECT_NO_THROW(ParseArgsWrapper());
+}
+TEST_F(SCCArgsBaseTests, SQLSchemaArgumentWithoutParameterTest) {
+  GTEST_SKIP() << "Argument without value did not throw an exception.";
+  AddArg("--sql-schema");
+
+  EXPECT_THROW(ParseArgsWrapper(), std::runtime_error);
+}
+
 TEST_F(SCCArgsBaseTests, SQLArgumentTest) {
-  const std::string sql_file = sql_path;
-  AddArg("--sql", sql_file);
+  const std::string sql_queries_file = sql_queries_path;
+  AddArg("--sql", sql_queries_file);
 
   EXPECT_NO_THROW(ParseArgsWrapper());
 }
@@ -54,7 +79,27 @@ TEST_F(SCCArgsTests, TranslateSchemaDefaultValueTest) {
   EXPECT_NO_THROW(ParseArgsWrapper());
 
   bool default_translate_schema_flag = parser.Get<bool>("--translate-schema");
-  EXPECT_TRUE(default_translate_schema_flag);
+  EXPECT_FALSE(default_translate_schema_flag);
+}
+
+TEST_F(SCCArgsTests, TranslateDataDefaultValueTest) {
+  EXPECT_NO_THROW(ParseArgsWrapper());
+
+  bool default_translate_data_flag = parser.Get<bool>("--translate-data");
+  EXPECT_FALSE(default_translate_data_flag);
+}
+
+TEST_F(SCCArgsTests, GraphSchemaArgumentDefaultValueTest) {
+  EXPECT_NO_THROW(ParseArgsWrapper());
+
+  std::string default_graph_schema_file = parser.Get("--graph-schema");
+  EXPECT_TRUE(default_graph_schema_file.find("schema.json") != std::string::npos);
+}
+TEST_F(SCCArgsTests, GraphSchemaArgumentWithoutParameterTest) {
+  GTEST_SKIP() << "Argument without value did not throw an exception.";
+  AddArg("--graph-schema");
+
+  EXPECT_THROW(ParseArgsWrapper(), std::runtime_error);
 }
 
 TEST_F(SCCArgsTests, CypherArgumentDefaultValueTest) {
@@ -191,7 +236,7 @@ TEST_F(SCCArgsTests, PresentUsedArgumentTest) {
   EXPECT_NO_THROW(ParseArgsWrapper());
   EXPECT_NO_THROW(
       std::optional<std::string> sql_value = parser.Present("--sql");
-      EXPECT_EQ(sql_value.value(), sql_path);
+      EXPECT_EQ(sql_value.value(), sql_queries_path);
   );
 }
 TEST_F(SCCArgsTests, PresentUnusedArgumentWithDefaultValueTest) {

--- a/test/config/scc_config_test.cpp
+++ b/test/config/scc_config_test.cpp
@@ -43,6 +43,12 @@ TEST_F(SCCConfigBaseTests, DoubleInitConfigTest) {
 }
 
 TEST_F(SCCConfigTests, DefaultConfigTest) {
+  // TODO: Implement few config fixtures to create config
+  //   1. without --translate-schema and --translate-data flags;
+  //   2. with --translate-schema and without --translate-data flags;
+  //   3. without --translate-schema and with --translate-data flags;
+  //   4. with --translate-schema and --translate-data flags.
+  GTEST_SKIP() << "Not implemented";
   logger::Severity default_log_severity = logger::Severity::info;
   EXPECT_EQ(default_log_severity, config->log_severity);
 
@@ -52,8 +58,11 @@ TEST_F(SCCConfigTests, DefaultConfigTest) {
   SCCMode default_mode = SCCMode::kInteractive;
   EXPECT_EQ(default_mode, config->mode);
 
-  bool default_translate_schema_flag = true;
+  bool default_translate_schema_flag = false;
   EXPECT_EQ(default_translate_schema_flag, config->translate_schema);
+
+  bool default_translate_data_flag = false;
+  EXPECT_EQ(default_translate_data_flag, config->translate_data);
 
   fs::path default_sql_file = fs::canonical(sql_queries_path);
   EXPECT_EQ(default_sql_file, config->get_sql_file());
@@ -64,6 +73,7 @@ TEST_F(SCCConfigTests, DefaultConfigTest) {
   EXPECT_TRUE(config->get_ast_dump_file().empty());
 }
 TEST_F(CustomSCCConfigTests, CustomConfigTest) {
+  GTEST_SKIP() << "Not implemented";
   AddArg("--translate-schema");
 
   std::string custom_sql_file = sql_queries_path;

--- a/test/config/scc_config_test.cpp
+++ b/test/config/scc_config_test.cpp
@@ -55,7 +55,7 @@ TEST_F(SCCConfigTests, DefaultConfigTest) {
   bool default_translate_schema_flag = true;
   EXPECT_EQ(default_translate_schema_flag, config->translate_schema);
 
-  fs::path default_sql_file = fs::canonical(sql_path);
+  fs::path default_sql_file = fs::canonical(sql_queries_path);
   EXPECT_EQ(default_sql_file, config->get_sql_file());
 
   fs::path default_cypher_file = fs::current_path() / "out.cql";
@@ -66,7 +66,7 @@ TEST_F(SCCConfigTests, DefaultConfigTest) {
 TEST_F(CustomSCCConfigTests, CustomConfigTest) {
   AddArg("--translate-schema");
 
-  std::string custom_sql_file = sql_path;
+  std::string custom_sql_file = sql_queries_path;
   AddArg("--sql", custom_sql_file);
 
   std::string custom_log_severity = std::string{logger::to_string(logger::Severity::fatal)};

--- a/test/fixtures/include/SCC/fixtures/config/scc_args_fixtures.h
+++ b/test/fixtures/include/SCC/fixtures/config/scc_args_fixtures.h
@@ -22,7 +22,8 @@ protected:
 
   Args args;
   scc::config::SCCArgs parser;
-  const std::string sql_path = scc::common::ResourcesPath() + "/sql_queries.sql";
+  const std::string sql_schema_path = scc::common::ResourcesPath() + "/schema.sql";
+  const std::string sql_queries_path = scc::common::ResourcesPath() + "/queries.sql";
 
   void ParseArgsWrapper();
   void AddArg(const std::string& option);
@@ -37,6 +38,7 @@ protected:
 
 class SCCArgsTests : public SCCArgsBaseTests {
 protected:
+  void AddSqlSchemaArgWithDefaultValue();
   void AddSqlArgWithDefaultValue();
 
   void SetUp() override;

--- a/test/fixtures/include/SCC/fixtures/config/scc_args_fixtures.h
+++ b/test/fixtures/include/SCC/fixtures/config/scc_args_fixtures.h
@@ -38,6 +38,8 @@ protected:
 
 class SCCArgsTests : public SCCArgsBaseTests {
 protected:
+  void AddTranslateSchemaOption();
+  void AddTranslateDataOption();
   void AddSqlSchemaArgWithDefaultValue();
   void AddSqlArgWithDefaultValue();
 

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -14,14 +14,15 @@ constexpr char indent_char = ' ';
 inline std::string dump(const json& j) {
   return j.dump(indent, indent_char);
 }
+
 template<typename T>
-inline std::string create_enum_json_string(T type) {
+inline std::string create_enum_json_string(const T& type) {
   return format(R"({{
   "value_": "{}"
 }})", type.ToString());
 }
 template<typename T>
-inline json create_enum_json(T type) {
+inline json create_enum_json(const T& type) {
   return json::parse(create_enum_json_string(type));
 }
 

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -6,8 +6,9 @@
 #include "nlohmann/json.hpp"
 
 #include "SCC/translator/cypher/graph/property_types.h"
-#include "SCC/translator/schema/property.h"
 #include "SCC/translator/schema/node.h"
+#include "SCC/translator/schema/property.h"
+#include "SCC/translator/schema/relationship.h"
 
 inline std::string dump(const nlohmann::json& j) {
   return j.dump();
@@ -22,10 +23,8 @@ inline nlohmann::json create_enum_json(const T& type) {
   return nlohmann::json::parse(create_enum_json_string(type));
 }
 
-inline std::string create_json_string(
-    const scc::translator::schema::PropertyConstraint& constraint
-) {
-  return format(R"({{"name":"{}","type":"{}"}})", constraint.name, constraint.type.ToString());
+inline std::string create_json_string(const scc::translator::schema::PropertyConstraint& constraint) {
+  return std::format(R"({{"name":"{}","type":"{}"}})", constraint.name, constraint.type.ToString());
 }
 inline nlohmann::json create_json(const scc::translator::schema::PropertyConstraint& constraint) {
   return nlohmann::json::parse(create_json_string(constraint));
@@ -36,13 +35,13 @@ inline std::string create_json_string(const scc::translator::schema::Property& p
   for (unsigned i = 0; i < property.Constraints().size(); ++i) {
     bool first = i == 0;
     const auto& constraint = property.Constraints()[i];
-    std::string constraint_json_string = format(R"({{"name":"{}","type":"{}"}})",
-                                                constraint.name, constraint.type.ToString());
+    std::string constraint_json_string = std::format(R"({{"name":"{}","type":"{}"}})",
+                                                     constraint.name, constraint.type.ToString());
     constraints_json_string += (first ? "" : ",") + constraint_json_string;
   }
 
-  return format(R"({{"constraints":[{}],"name":"{}","type":"{}"}})",
-                constraints_json_string, property.name, property.type.ToString());
+  return std::format(R"({{"constraints":[{}],"name":"{}","type":"{}"}})",
+                     constraints_json_string, property.name, property.type.ToString());
 }
 inline nlohmann::json create_json(const scc::translator::schema::Property& property) {
   return nlohmann::json::parse(create_json_string(property));
@@ -57,10 +56,17 @@ inline std::string create_json_string(const scc::translator::schema::Node& node)
     properties_json_string += (first ? "" : ",") + property_json_string;
   }
 
-  return format(R"({{"label":"{}","properties":[{}]}})", node.label, properties_json_string);
+  return std::format(R"({{"label":"{}","properties":[{}]}})", node.label, properties_json_string);
 }
 inline nlohmann::json create_json(const scc::translator::schema::Node& node) {
   return nlohmann::json::parse(create_json_string(node));
+}
+
+inline std::string create_json_string(const scc::translator::schema::ApplyCondition& condition) {
+  return std::format(R"({{"epi":{},"spi":{}}})", condition.epi, condition.spi);
+}
+inline nlohmann::json create_json(const scc::translator::schema::ApplyCondition& condition) {
+  return nlohmann::json::parse(create_json_string(condition));
 }
 
 template<typename T>

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <format>
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+using std::format;
+using nlohmann::json;
+
+constexpr int indent = 2;
+constexpr char indent_char = ' ';
+
+inline std::string dump(const json& j) {
+  return j.dump(indent, indent_char);
+}
+template<typename T>
+inline std::string create_enum_json_string(T type) {
+  return format(R"({{
+  "value_": "{}"
+}})", type.ToString());
+}
+template<typename T>
+inline json create_enum_json(T type) {
+  return json::parse(create_enum_json_string(type));
+}

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -5,38 +5,35 @@
 
 #include "nlohmann/json.hpp"
 
-using std::format;
-using nlohmann::json;
-
 constexpr int indent = 2;
 constexpr char indent_char = ' ';
 
-inline std::string dump(const json& j) {
+inline std::string dump(const nlohmann::json& j) {
   return j.dump(indent, indent_char);
 }
 
 template<typename T>
 inline std::string create_enum_json_string(const T& type) {
-  return format(R"({{
+  return std::format(R"({{
   "value_": "{}"
 }})", type.ToString());
 }
 template<typename T>
-inline json create_enum_json(const T& type) {
-  return json::parse(create_enum_json_string(type));
+inline nlohmann::json create_enum_json(const T& type) {
+  return nlohmann::json::parse(create_enum_json_string(type));
 }
 
 template<typename T>
 inline void EnumToJsonTestBody(const T& type, const std::string_view& expected) {
   ASSERT_NO_THROW(
-      json type_json = type;
+      nlohmann::json type_json = type;
       EXPECT_EQ(expected, type_json);
   );
 }
 template<typename T>
 inline void EnumFromJsonTestBody(const std::string_view& json_str, const T& expected) {
   ASSERT_NO_THROW(
-      json type_json = json_str;
+      nlohmann::json type_json = json_str;
       EXPECT_EQ(expected, type_json.template get<T>());
   );
 }
@@ -44,7 +41,7 @@ inline void EnumFromJsonTestBody(const std::string_view& json_str, const T& expe
 template<typename T>
 inline void EnumClassToJsonTestBody(const T& type) {
   ASSERT_NO_THROW(
-      json type_json;
+      nlohmann::json type_json;
       to_json(type_json, type);
       EXPECT_EQ(create_enum_json_string(type), dump(type_json));
   );
@@ -53,7 +50,7 @@ template<typename T>
 inline void EnumClassFromJsonTestBody(const T& type) {
   ASSERT_NO_THROW(
       T type_from_json;
-      json type_json = create_enum_json(type);
+      nlohmann::json type_json = create_enum_json(type);
       from_json(type_json, type_from_json);
       EXPECT_EQ(type, type_from_json);
   );
@@ -62,13 +59,13 @@ inline void EnumClassFromJsonTestBody(const T& type) {
 template<typename T>
 inline void ObjectToJsonTestBody(const T& object, const std::string& expected) {
   ASSERT_NO_THROW(
-      json object_json;
+      nlohmann::json object_json;
       to_json(object_json, object);
       EXPECT_EQ(expected, dump(object_json));
   );
 }
 template<typename T>
-inline void ObjectFromJsonTestBody(const json& object_json, const T& expected_object) {
+inline void ObjectFromJsonTestBody(const nlohmann::json& object_json, const T& expected_object) {
   ASSERT_NO_THROW(
       T object_from_json;
       from_json(object_json, object_from_json);

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -58,3 +58,20 @@ inline void EnumClassFromJsonTestBody(const T& type) {
       EXPECT_EQ(type, type_from_json);
   );
 }
+
+template<typename T>
+inline void ObjectToJsonTestBody(const T& object, const std::string& expected) {
+  ASSERT_NO_THROW(
+      json object_json;
+      to_json(object_json, object);
+      EXPECT_EQ(expected, dump(object_json));
+  );
+}
+template<typename T>
+inline void ObjectFromJsonTestBody(const json& object_json, const T& expected_object) {
+  ASSERT_NO_THROW(
+      T object_from_json;
+      from_json(object_json, object_from_json);
+      EXPECT_EQ(expected_object, object_from_json);
+  );
+}

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -5,6 +5,9 @@
 
 #include "nlohmann/json.hpp"
 
+#include "SCC/translator/cypher/graph/property_types.h"
+#include "SCC/translator/schema/property.h"
+
 constexpr int indent = 2;
 constexpr char indent_char = ' ';
 
@@ -21,6 +24,47 @@ inline std::string create_enum_json_string(const T& type) {
 template<typename T>
 inline nlohmann::json create_enum_json(const T& type) {
   return nlohmann::json::parse(create_enum_json_string(type));
+}
+
+inline std::string create_json_string(
+    const scc::translator::schema::PropertyConstraint& constraint
+) {
+  return format(R"({{
+  "name": "{}",
+  "type": "{}"
+}})", constraint.name, constraint.type.ToString());
+}
+inline nlohmann::json create_json(const scc::translator::schema::PropertyConstraint& constraint) {
+  return nlohmann::json::parse(create_json_string(constraint));
+}
+
+inline std::string create_json_string(const scc::translator::schema::Property& property) {
+  std::string constraints_json_string;
+  for (unsigned i = 0; i < property.Constraints().size(); ++i) {
+    bool first = i == 0;
+    bool last = i == property.Constraints().size() - 1;
+    if (first) {
+      constraints_json_string += "\n";
+    }
+    const auto& constraint = property.Constraints()[i];
+    std::string constraint_json_string = format(R"(    {{
+      "name": "{}",
+      "type": "{}"
+    }}{})", constraint.name, constraint.type.ToString(), (last  ? "" : ",\n"));
+    constraints_json_string += constraint_json_string;
+    if (last) {
+      constraints_json_string += "\n  ";
+    }
+  }
+
+  return format(R"({{
+  "constraints": [{}],
+  "name": "{}",
+  "type": "{}"
+}})", constraints_json_string, property.name, property.type.ToString());
+}
+inline nlohmann::json create_json(const scc::translator::schema::Property& property) {
+  return nlohmann::json::parse(create_json_string(property));
 }
 
 template<typename T>

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -115,7 +115,7 @@ template<typename T>
 inline void EnumToJsonTestBody(const T& type, const std::string_view& expected) {
   ASSERT_NO_THROW(
       nlohmann::json type_json = type;
-      EXPECT_EQ(expected, type_json);
+      EXPECT_EQ(nlohmann::json(expected), type_json);
   );
 }
 template<typename T>

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -24,3 +24,36 @@ template<typename T>
 inline json create_enum_json(T type) {
   return json::parse(create_enum_json_string(type));
 }
+
+template<typename T>
+inline void EnumToJsonTestBody(const T& type, const std::string_view& expected) {
+  ASSERT_NO_THROW(
+      json type_json = type;
+      EXPECT_EQ(expected, type_json);
+  );
+}
+template<typename T>
+inline void EnumFromJsonTestBody(const std::string_view& json_str, const T& expected) {
+  ASSERT_NO_THROW(
+      json type_json = json_str;
+      EXPECT_EQ(expected, type_json.template get<T>());
+  );
+}
+
+template<typename T>
+inline void EnumClassToJsonTestBody(const T& type) {
+  ASSERT_NO_THROW(
+      json type_json;
+      to_json(type_json, type);
+      EXPECT_EQ(create_enum_json_string(type), dump(type_json));
+  );
+}
+template<typename T>
+inline void EnumClassFromJsonTestBody(const T& type) {
+  ASSERT_NO_THROW(
+      T type_from_json;
+      json type_json = create_enum_json(type);
+      from_json(type_json, type_from_json);
+      EXPECT_EQ(type, type_from_json);
+  );
+}

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -8,18 +8,13 @@
 #include "SCC/translator/cypher/graph/property_types.h"
 #include "SCC/translator/schema/property.h"
 
-constexpr int indent = 2;
-constexpr char indent_char = ' ';
-
 inline std::string dump(const nlohmann::json& j) {
-  return j.dump(indent, indent_char);
+  return j.dump();
 }
 
 template<typename T>
 inline std::string create_enum_json_string(const T& type) {
-  return std::format(R"({{
-  "value_": "{}"
-}})", type.ToString());
+  return std::format(R"({{"value_":"{}"}})", type.ToString());
 }
 template<typename T>
 inline nlohmann::json create_enum_json(const T& type) {
@@ -29,10 +24,7 @@ inline nlohmann::json create_enum_json(const T& type) {
 inline std::string create_json_string(
     const scc::translator::schema::PropertyConstraint& constraint
 ) {
-  return format(R"({{
-  "name": "{}",
-  "type": "{}"
-}})", constraint.name, constraint.type.ToString());
+  return format(R"({{"name":"{}","type":"{}"}})", constraint.name, constraint.type.ToString());
 }
 inline nlohmann::json create_json(const scc::translator::schema::PropertyConstraint& constraint) {
   return nlohmann::json::parse(create_json_string(constraint));
@@ -42,26 +34,14 @@ inline std::string create_json_string(const scc::translator::schema::Property& p
   std::string constraints_json_string;
   for (unsigned i = 0; i < property.Constraints().size(); ++i) {
     bool first = i == 0;
-    bool last = i == property.Constraints().size() - 1;
-    if (first) {
-      constraints_json_string += "\n";
-    }
     const auto& constraint = property.Constraints()[i];
-    std::string constraint_json_string = format(R"(    {{
-      "name": "{}",
-      "type": "{}"
-    }}{})", constraint.name, constraint.type.ToString(), (last  ? "" : ",\n"));
-    constraints_json_string += constraint_json_string;
-    if (last) {
-      constraints_json_string += "\n  ";
-    }
+    std::string constraint_json_string = format(R"({{"name":"{}","type":"{}"}})",
+                                                constraint.name, constraint.type.ToString());
+    constraints_json_string += (first ? "" : ",") + constraint_json_string;
   }
 
-  return format(R"({{
-  "constraints": [{}],
-  "name": "{}",
-  "type": "{}"
-}})", constraints_json_string, property.name, property.type.ToString());
+  return format(R"({{"constraints":[{}],"name":"{}","type":"{}"}})",
+                constraints_json_string, property.name, property.type.ToString());
 }
 inline nlohmann::json create_json(const scc::translator::schema::Property& property) {
   return nlohmann::json::parse(create_json_string(property));

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -69,6 +69,22 @@ inline nlohmann::json create_json(const scc::translator::schema::ApplyCondition&
   return nlohmann::json::parse(create_json_string(condition));
 }
 
+inline std::string create_json_string(const scc::translator::schema::Relationship& relationship) {
+  std::string conditions_json_string;
+  for (unsigned i = 0; i < relationship.Conditions().size(); ++i) {
+    bool first = i == 0;
+    const auto& condition = relationship.Conditions()[i];
+    std::string condition_json_string = create_json_string(condition);
+    conditions_json_string += (first ? "" : ",") + condition_json_string;
+  }
+
+  return format(R"({{"conditions":[{}],"end":"{}","start":"{}","type":"{}"}})",
+                conditions_json_string, relationship.end, relationship.start, relationship.type);
+}
+inline nlohmann::json create_json(const scc::translator::schema::Relationship& relationship) {
+  return nlohmann::json::parse(create_json_string(relationship));
+}
+
 template<typename T>
 inline void EnumToJsonTestBody(const T& type, const std::string_view& expected) {
   ASSERT_NO_THROW(

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -9,6 +9,7 @@
 #include "SCC/translator/schema/node.h"
 #include "SCC/translator/schema/property.h"
 #include "SCC/translator/schema/relationship.h"
+#include "SCC/translator/schema/schema.h"
 
 inline std::string dump(const nlohmann::json& j) {
   return j.dump();
@@ -78,11 +79,36 @@ inline std::string create_json_string(const scc::translator::schema::Relationshi
     conditions_json_string += (first ? "" : ",") + condition_json_string;
   }
 
-  return format(R"({{"conditions":[{}],"end":"{}","start":"{}","type":"{}"}})",
-                conditions_json_string, relationship.end, relationship.start, relationship.type);
+  return std::format(R"({{"conditions":[{}],"end":"{}","start":"{}","type":"{}"}})",
+                     conditions_json_string, relationship.end, relationship.start,
+                     relationship.type);
 }
 inline nlohmann::json create_json(const scc::translator::schema::Relationship& relationship) {
   return nlohmann::json::parse(create_json_string(relationship));
+}
+
+inline std::string create_json_string(const scc::translator::schema::Schema& schema) {
+  std::string nodes_json_string;
+  for (unsigned i = 0; i < schema.Nodes().size(); ++i) {
+    bool first = i == 0;
+    const auto& node = schema.Nodes()[i];
+    std::string node_json_string = create_json_string(node);
+    nodes_json_string += (first ? "" : ",") + node_json_string;
+  }
+
+  std::string relationships_json_string;
+  for (unsigned i = 0; i < schema.Relationships().size(); ++i) {
+    bool first = i == 0;
+    const auto& relationship = schema.Relationships()[i];
+    std::string relationship_json_string = create_json_string(relationship);
+    relationships_json_string += (first ? "" : ",") + relationship_json_string;
+  }
+
+  return std::format(R"({{"database_name":"{}","nodes":[{}],"relationships":[{}]}})",
+                     schema.database_name, nodes_json_string, relationships_json_string);
+}
+inline nlohmann::json create_json(const scc::translator::schema::Schema& schema) {
+  return nlohmann::json::parse(create_json_string(schema));
 }
 
 template<typename T>

--- a/test/fixtures/include/SCC/fixtures_common/serialization.h
+++ b/test/fixtures/include/SCC/fixtures_common/serialization.h
@@ -7,6 +7,7 @@
 
 #include "SCC/translator/cypher/graph/property_types.h"
 #include "SCC/translator/schema/property.h"
+#include "SCC/translator/schema/node.h"
 
 inline std::string dump(const nlohmann::json& j) {
   return j.dump();
@@ -45,6 +46,21 @@ inline std::string create_json_string(const scc::translator::schema::Property& p
 }
 inline nlohmann::json create_json(const scc::translator::schema::Property& property) {
   return nlohmann::json::parse(create_json_string(property));
+}
+
+inline std::string create_json_string(const scc::translator::schema::Node& node) {
+  std::string properties_json_string;
+  for (unsigned i = 0; i < node.properties.size(); ++i) {
+    bool first = i == 0;
+    const auto& property = node.properties[i];
+    std::string property_json_string = create_json_string(property);
+    properties_json_string += (first ? "" : ",") + property_json_string;
+  }
+
+  return format(R"({{"label":"{}","properties":[{}]}})", node.label, properties_json_string);
+}
+inline nlohmann::json create_json(const scc::translator::schema::Node& node) {
+  return nlohmann::json::parse(create_json_string(node));
 }
 
 template<typename T>

--- a/test/fixtures/src/config/scc_args_fixtures.cpp
+++ b/test/fixtures/src/config/scc_args_fixtures.cpp
@@ -44,8 +44,11 @@ void SCCArgsBaseTests::TearDown() {
   DeleteArgs();
 }
 
+void SCCArgsTests::AddSqlSchemaArgWithDefaultValue() {
+  AddArg("--sql-schema", sql_schema_path);
+}
 void SCCArgsTests::AddSqlArgWithDefaultValue() {
-  AddArg("--sql", sql_path);
+  AddArg("--sql", sql_queries_path);
 }
 
 void SCCArgsTests::SetUp() {

--- a/test/fixtures/src/config/scc_args_fixtures.cpp
+++ b/test/fixtures/src/config/scc_args_fixtures.cpp
@@ -44,6 +44,12 @@ void SCCArgsBaseTests::TearDown() {
   DeleteArgs();
 }
 
+void SCCArgsTests::AddTranslateSchemaOption() {
+  AddArg("--translate-schema");
+}
+void SCCArgsTests::AddTranslateDataOption() {
+  AddArg("--translate-data");
+}
 void SCCArgsTests::AddSqlSchemaArgWithDefaultValue() {
   AddArg("--sql-schema", sql_schema_path);
 }
@@ -53,6 +59,7 @@ void SCCArgsTests::AddSqlArgWithDefaultValue() {
 
 void SCCArgsTests::SetUp() {
   SCCArgsBaseTests::SetUp();
+  AddSqlSchemaArgWithDefaultValue();
   AddSqlArgWithDefaultValue();
 }
 void SCCArgsTests::TearDown() {

--- a/test/fixtures/src/config/scc_config_fixtures.cpp
+++ b/test/fixtures/src/config/scc_config_fixtures.cpp
@@ -4,6 +4,8 @@ using namespace scc::config;
 
 void SCCConfigBaseTests::SetUp() {
   SCCArgsTests::SetUp();
+  SCCArgsTests::AddTranslateSchemaOption();
+  SCCArgsTests::AddTranslateDataOption();
   ParseArgsWrapper();
 }
 void SCCConfigBaseTests::TearDown() {

--- a/test/translator/CMakeLists.txt
+++ b/test/translator/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(DIRS
         cypher
+        schema
 )
 foreach(DIR ${DIRS})
     add_subdirectory(${DIR})

--- a/test/translator/CMakeLists.txt
+++ b/test/translator/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(DIRS
+        cypher
+)
+foreach(DIR ${DIRS})
+    add_subdirectory(${DIR})
+endforeach()

--- a/test/translator/cypher/CMakeLists.txt
+++ b/test/translator/cypher/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(DIRS
+        graph
+)
+foreach(DIR ${DIRS})
+    add_subdirectory(${DIR})
+endforeach()

--- a/test/translator/cypher/graph/CMakeLists.txt
+++ b/test/translator/cypher/graph/CMakeLists.txt
@@ -1,3 +1,4 @@
 scc_test(scc_test_translator_cypher_graph
         constraint_types_serialization_test.cpp
+        property_types_serialization_test.cpp
 )

--- a/test/translator/cypher/graph/CMakeLists.txt
+++ b/test/translator/cypher/graph/CMakeLists.txt
@@ -1,0 +1,3 @@
+scc_test(scc_test_translator_cypher_graph
+        constraint_types_serialization_test.cpp
+)

--- a/test/translator/cypher/graph/constraint_types_serialization_test.cpp
+++ b/test/translator/cypher/graph/constraint_types_serialization_test.cpp
@@ -12,91 +12,23 @@ using namespace testing;
 using nlohmann::json;
 
 TEST(CypherConstraintTypeSerializationTests, EnumToJsonTest) {
-  ASSERT_NO_THROW(
-      json none_json = ConstraintType::Value::kNone;
-      EXPECT_EQ(kCT_None, none_json);
-  );
-
-  ASSERT_NO_THROW(
-      json unique_json = ConstraintType::Value::kUniqueness;
-      EXPECT_EQ(kCT_Uniqueness, unique_json);
-  );
-
-  ASSERT_NO_THROW(
-      json not_null_json = ConstraintType::Value::kExistence;
-      EXPECT_EQ(kCT_Existence, not_null_json);
-  );
+  EnumToJsonTestBody<ConstraintType::Value>(ConstraintType::Value::kNone, kCT_None);
+  EnumToJsonTestBody<ConstraintType::Value>(ConstraintType::Value::kUniqueness, kCT_Uniqueness);
+  EnumToJsonTestBody<ConstraintType::Value>(ConstraintType::Value::kExistence, kCT_Existence);
 }
 TEST(CypherConstraintTypeSerializationTests, EnumFromJsonTest) {
-  ASSERT_NO_THROW(
-      json none_json = kCT_None;
-      EXPECT_EQ(ConstraintType::Value::kNone,
-                none_json.template get<ConstraintType::Value>());
-  );
-
-  ASSERT_NO_THROW(
-      json unique_json = kCT_Uniqueness;
-      EXPECT_EQ(ConstraintType::Value::kUniqueness,
-                unique_json.template get<ConstraintType::Value>());
-  );
-
-  ASSERT_NO_THROW(
-      json not_null_json = kCT_Existence;
-      EXPECT_EQ(ConstraintType::Value::kExistence,
-                not_null_json.template get<ConstraintType::Value>());
-  );
+  EnumFromJsonTestBody<ConstraintType::Value>(kCT_None, ConstraintType::Value::kNone);
+  EnumFromJsonTestBody<ConstraintType::Value>(kCT_Uniqueness, ConstraintType::Value::kUniqueness);
+  EnumFromJsonTestBody<ConstraintType::Value>(kCT_Existence, ConstraintType::Value::kExistence);
 }
 
 TEST(CypherConstraintTypeSerializationTests, ToJsonTest) {
-  ASSERT_NO_THROW(
-      ConstraintType none_type = ConstraintType::kNone;
-
-      json none_json;
-      to_json(none_json, none_type);
-      EXPECT_EQ(create_enum_json_string(none_type), dump(none_json));
-  );
-
-  ASSERT_NO_THROW(
-      ConstraintType unique_type = ConstraintType::kUniqueness;
-
-      json unique_json;
-      to_json(unique_json, unique_type);
-      EXPECT_EQ(create_enum_json_string(unique_type), dump(unique_json));
-  );
-
-  ASSERT_NO_THROW(
-      ConstraintType not_null_type = ConstraintType::kExistence;
-
-      json not_null_json;
-      to_json(not_null_json, not_null_type);
-      EXPECT_EQ(create_enum_json_string(not_null_type), dump(not_null_json));
-  );
+  EnumClassToJsonTestBody<ConstraintType>(ConstraintType::kNone);
+  EnumClassToJsonTestBody<ConstraintType>(ConstraintType::kUniqueness);
+  EnumClassToJsonTestBody<ConstraintType>(ConstraintType::kExistence);
 }
 TEST(CypherConstraintTypeSerializationTests, FromJsonTest) {
-  ASSERT_NO_THROW(
-      ConstraintType none_type = ConstraintType::kNone;
-      ConstraintType none_type_from_json;
-
-      json none_json = create_enum_json(none_type);
-      from_json(none_json, none_type_from_json);
-      EXPECT_EQ(none_type, none_type_from_json);
-  );
-
-  ASSERT_NO_THROW(
-      ConstraintType unique_type = ConstraintType::kUniqueness;
-      ConstraintType unique_type_from_json;
-
-      json unique_json = create_enum_json(unique_type);
-      from_json(unique_json, unique_type_from_json);
-      EXPECT_EQ(unique_json, unique_type_from_json);
-  );
-
-  ASSERT_NO_THROW(
-      ConstraintType not_null_type = ConstraintType::kExistence;
-      ConstraintType not_null_type_from_json;
-
-      json not_null_json = create_enum_json(not_null_type);
-      from_json(not_null_json, not_null_type_from_json);
-      EXPECT_EQ(not_null_json, not_null_type_from_json);
-  );
+  EnumClassFromJsonTestBody<ConstraintType>(ConstraintType::kNone);
+  EnumClassFromJsonTestBody<ConstraintType>(ConstraintType::kUniqueness);
+  EnumClassFromJsonTestBody<ConstraintType>(ConstraintType::kExistence);
 }

--- a/test/translator/cypher/graph/constraint_types_serialization_test.cpp
+++ b/test/translator/cypher/graph/constraint_types_serialization_test.cpp
@@ -1,15 +1,10 @@
-#include <string>
-
 #include "gtest/gtest.h"
-
-#include "nlohmann/json.hpp"
 
 #include "SCC/fixtures_common/serialization.h"
 #include "SCC/translator/cypher/graph/constraint_types.h"
 
 using namespace scc::translator::cypher;
 using namespace testing;
-using nlohmann::json;
 
 TEST(CypherConstraintTypeSerializationTests, EnumToJsonTest) {
   EnumToJsonTestBody<ConstraintType::Value>(ConstraintType::Value::kNone, kCT_None);

--- a/test/translator/cypher/graph/constraint_types_serialization_test.cpp
+++ b/test/translator/cypher/graph/constraint_types_serialization_test.cpp
@@ -1,0 +1,102 @@
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "nlohmann/json.hpp"
+
+#include "SCC/fixtures_common/serialization.h"
+#include "SCC/translator/cypher/graph/constraint_types.h"
+
+using namespace scc::translator::cypher;
+using namespace testing;
+using nlohmann::json;
+
+TEST(CypherConstraintTypeSerializationTests, EnumToJsonTest) {
+  ASSERT_NO_THROW(
+      json none_json = ConstraintType::Value::kNone;
+      EXPECT_EQ(kCT_None, none_json);
+  );
+
+  ASSERT_NO_THROW(
+      json unique_json = ConstraintType::Value::kUniqueness;
+      EXPECT_EQ(kCT_Uniqueness, unique_json);
+  );
+
+  ASSERT_NO_THROW(
+      json not_null_json = ConstraintType::Value::kExistence;
+      EXPECT_EQ(kCT_Existence, not_null_json);
+  );
+}
+TEST(CypherConstraintTypeSerializationTests, EnumFromJsonTest) {
+  ASSERT_NO_THROW(
+      json none_json = kCT_None;
+      EXPECT_EQ(ConstraintType::Value::kNone,
+                none_json.template get<ConstraintType::Value>());
+  );
+
+  ASSERT_NO_THROW(
+      json unique_json = kCT_Uniqueness;
+      EXPECT_EQ(ConstraintType::Value::kUniqueness,
+                unique_json.template get<ConstraintType::Value>());
+  );
+
+  ASSERT_NO_THROW(
+      json not_null_json = kCT_Existence;
+      EXPECT_EQ(ConstraintType::Value::kExistence,
+                not_null_json.template get<ConstraintType::Value>());
+  );
+}
+
+TEST(CypherConstraintTypeSerializationTests, ToJsonTest) {
+  ASSERT_NO_THROW(
+      ConstraintType none_type = ConstraintType::kNone;
+
+      json none_json;
+      to_json(none_json, none_type);
+      EXPECT_EQ(create_enum_json_string(none_type), dump(none_json));
+  );
+
+  ASSERT_NO_THROW(
+      ConstraintType unique_type = ConstraintType::kUniqueness;
+
+      json unique_json;
+      to_json(unique_json, unique_type);
+      EXPECT_EQ(create_enum_json_string(unique_type), dump(unique_json));
+  );
+
+  ASSERT_NO_THROW(
+      ConstraintType not_null_type = ConstraintType::kExistence;
+
+      json not_null_json;
+      to_json(not_null_json, not_null_type);
+      EXPECT_EQ(create_enum_json_string(not_null_type), dump(not_null_json));
+  );
+}
+TEST(CypherConstraintTypeSerializationTests, FromJsonTest) {
+  ASSERT_NO_THROW(
+      ConstraintType none_type = ConstraintType::kNone;
+      ConstraintType none_type_from_json;
+
+      json none_json = create_enum_json(none_type);
+      from_json(none_json, none_type_from_json);
+      EXPECT_EQ(none_type, none_type_from_json);
+  );
+
+  ASSERT_NO_THROW(
+      ConstraintType unique_type = ConstraintType::kUniqueness;
+      ConstraintType unique_type_from_json;
+
+      json unique_json = create_enum_json(unique_type);
+      from_json(unique_json, unique_type_from_json);
+      EXPECT_EQ(unique_json, unique_type_from_json);
+  );
+
+  ASSERT_NO_THROW(
+      ConstraintType not_null_type = ConstraintType::kExistence;
+      ConstraintType not_null_type_from_json;
+
+      json not_null_json = create_enum_json(not_null_type);
+      from_json(not_null_json, not_null_type_from_json);
+      EXPECT_EQ(not_null_json, not_null_type_from_json);
+  );
+}

--- a/test/translator/cypher/graph/property_types_serialization_test.cpp
+++ b/test/translator/cypher/graph/property_types_serialization_test.cpp
@@ -1,0 +1,40 @@
+#include "gtest/gtest.h"
+
+#include "nlohmann/json.hpp"
+
+#include "SCC/fixtures_common/serialization.h"
+#include "SCC/translator/cypher/graph/property_types.h"
+
+using namespace scc::translator::cypher;
+using namespace testing;
+using nlohmann::json;
+
+TEST(CypherPropertyTypeSerializationTests, EnumToJsonTest) {
+  EnumToJsonTestBody<PropertyType::Value>(PropertyType::Value::kUnknown, kPT_Unknown);
+  EnumToJsonTestBody<PropertyType::Value>(PropertyType::Value::kBoolean, kPT_Boolean);
+  EnumToJsonTestBody<PropertyType::Value>(PropertyType::Value::kFloat, kPT_Float);
+  EnumToJsonTestBody<PropertyType::Value>(PropertyType::Value::kInteger, kPT_Integer);
+  EnumToJsonTestBody<PropertyType::Value>(PropertyType::Value::kString, kPT_String);
+}
+TEST(CypherPropertyTypeSerializationTests, EnumFromJsonTest) {
+  EnumFromJsonTestBody<PropertyType::Value>(kPT_Unknown, PropertyType::Value::kUnknown);
+  EnumFromJsonTestBody<PropertyType::Value>(kPT_Boolean, PropertyType::Value::kBoolean);
+  EnumFromJsonTestBody<PropertyType::Value>(kPT_Float, PropertyType::Value::kFloat);
+  EnumFromJsonTestBody<PropertyType::Value>(kPT_Integer, PropertyType::Value::kInteger);
+  EnumFromJsonTestBody<PropertyType::Value>(kPT_String, PropertyType::Value::kString);
+}
+
+TEST(CypherPropertyTypeSerializationTests, ToJsonTest) {
+  EnumClassToJsonTestBody<PropertyType>(PropertyType::kUnknown);
+  EnumClassToJsonTestBody<PropertyType>(PropertyType::kBoolean);
+  EnumClassToJsonTestBody<PropertyType>(PropertyType::kFloat);
+  EnumClassToJsonTestBody<PropertyType>(PropertyType::kInteger);
+  EnumClassToJsonTestBody<PropertyType>(PropertyType::kString);
+}
+TEST(CypherPropertyTypeSerializationTests, FromJsonTest) {
+  EnumClassFromJsonTestBody<PropertyType>(PropertyType::kUnknown);
+  EnumClassFromJsonTestBody<PropertyType>(PropertyType::kBoolean);
+  EnumClassFromJsonTestBody<PropertyType>(PropertyType::kFloat);
+  EnumClassFromJsonTestBody<PropertyType>(PropertyType::kInteger);
+  EnumClassFromJsonTestBody<PropertyType>(PropertyType::kString);
+}

--- a/test/translator/cypher/graph/property_types_serialization_test.cpp
+++ b/test/translator/cypher/graph/property_types_serialization_test.cpp
@@ -1,13 +1,10 @@
 #include "gtest/gtest.h"
 
-#include "nlohmann/json.hpp"
-
 #include "SCC/fixtures_common/serialization.h"
 #include "SCC/translator/cypher/graph/property_types.h"
 
 using namespace scc::translator::cypher;
 using namespace testing;
-using nlohmann::json;
 
 TEST(CypherPropertyTypeSerializationTests, EnumToJsonTest) {
   EnumToJsonTestBody<PropertyType::Value>(PropertyType::Value::kUnknown, kPT_Unknown);

--- a/test/translator/schema/CMakeLists.txt
+++ b/test/translator/schema/CMakeLists.txt
@@ -1,3 +1,4 @@
 scc_test(scc_test_translator_schema
+        node_serialization_test.cpp
         property_serialization_test.cpp
 )

--- a/test/translator/schema/CMakeLists.txt
+++ b/test/translator/schema/CMakeLists.txt
@@ -2,4 +2,5 @@ scc_test(scc_test_translator_schema
         node_serialization_test.cpp
         property_serialization_test.cpp
         relationship_serialization_test.cpp
+        schema_serialization_test.cpp
 )

--- a/test/translator/schema/CMakeLists.txt
+++ b/test/translator/schema/CMakeLists.txt
@@ -1,4 +1,5 @@
 scc_test(scc_test_translator_schema
         node_serialization_test.cpp
         property_serialization_test.cpp
+        relationship_serialization_test.cpp
 )

--- a/test/translator/schema/CMakeLists.txt
+++ b/test/translator/schema/CMakeLists.txt
@@ -1,0 +1,3 @@
+scc_test(scc_test_translator_schema
+        property_serialization_test.cpp
+)

--- a/test/translator/schema/node_serialization_test.cpp
+++ b/test/translator/schema/node_serialization_test.cpp
@@ -1,0 +1,31 @@
+#include "gtest/gtest.h"
+
+#include "nlohmann/json.hpp"
+
+#include "SCC/fixtures_common/serialization.h"
+#include "SCC/translator/cypher/graph/property_types.h"
+#include "SCC/translator/schema/node.h"
+#include "SCC/translator/schema/property.h"
+
+using namespace scc::translator::schema;
+using namespace testing;
+using nlohmann::json;
+using scc::translator::cypher::PropertyType;
+
+TEST(SchemaNodeSerializationTests, ToJsonTest) {
+  Node person("Person");
+  ObjectToJsonTestBody<Node>(person, create_json_string(person));
+
+  person.AddProperty(Property("firstname", PropertyType::kString));
+  person.AddProperty(Property("age", PropertyType::kInteger));
+  ObjectToJsonTestBody<Node>(person, create_json_string(person));
+}
+TEST(SchemaNodeSerializationTests, FromJsonTest) {
+  Node laptop("Laptop");
+  ObjectFromJsonTestBody<Node>(create_json(laptop), laptop);
+
+  laptop.AddProperty(Property("brand", PropertyType::kString));
+  laptop.AddProperty(Property("model", PropertyType::kString));
+  laptop.AddProperty(Property("weight", PropertyType::kFloat));
+  ObjectFromJsonTestBody<Node>(create_json(laptop), laptop);
+}

--- a/test/translator/schema/property_serialization_test.cpp
+++ b/test/translator/schema/property_serialization_test.cpp
@@ -1,0 +1,42 @@
+#include <format>
+
+#include "gtest/gtest.h"
+
+#include "nlohmann/json.hpp"
+
+#include "SCC/fixtures_common/serialization.h"
+#include "SCC/translator/cypher/graph/constraint_types.h"
+#include "SCC/translator/cypher/graph/property_types.h"
+#include "SCC/translator/schema/property.h"
+
+using namespace scc::translator::schema;
+using namespace testing;
+using std::format;
+using nlohmann::json;
+using scc::translator::cypher::ConstraintType;
+using scc::translator::cypher::PropertyType;
+
+inline std::string create_json_string(const PropertyConstraint& constraint) {
+  return format(R"({{
+  "name": "{}",
+  "type": "{}"
+}})", constraint.name, constraint.type.ToString());
+}
+inline json create_json(const PropertyConstraint& constraint) {
+  return json::parse(create_json_string(constraint));
+}
+
+TEST(SchemaPropertyConstraintSerializationTests, ToJsonTest) {
+  PropertyConstraint empty_constraint("", ConstraintType::kNone);
+  ObjectToJsonTestBody<PropertyConstraint>(empty_constraint, create_json_string(empty_constraint));
+
+  PropertyConstraint constraint("to_json_constraint", ConstraintType::kExistence);
+  ObjectToJsonTestBody<PropertyConstraint>(constraint, create_json_string(constraint));
+}
+TEST(SchemaPropertyConstraintSerializationTests, FromJsonTest)  {
+  PropertyConstraint empty_constraint("", ConstraintType::kNone);
+  ObjectFromJsonTestBody<PropertyConstraint>(create_json(empty_constraint), empty_constraint);
+
+  PropertyConstraint constraint("from_json_constraint", ConstraintType::kUniqueness);
+  ObjectFromJsonTestBody<PropertyConstraint>(create_json(constraint), constraint);
+}

--- a/test/translator/schema/property_serialization_test.cpp
+++ b/test/translator/schema/property_serialization_test.cpp
@@ -1,8 +1,4 @@
-#include <format>
-
 #include "gtest/gtest.h"
-
-#include "nlohmann/json.hpp"
 
 #include "SCC/fixtures_common/serialization.h"
 #include "SCC/translator/cypher/graph/constraint_types.h"
@@ -11,49 +7,8 @@
 
 using namespace scc::translator::schema;
 using namespace testing;
-using std::format;
-using nlohmann::json;
 using scc::translator::cypher::ConstraintType;
 using scc::translator::cypher::PropertyType;
-
-inline std::string create_json_string(const PropertyConstraint& constraint) {
-  return format(R"({{
-  "name": "{}",
-  "type": "{}"
-}})", constraint.name, constraint.type.ToString());
-}
-inline json create_json(const PropertyConstraint& constraint) {
-  return json::parse(create_json_string(constraint));
-}
-
-inline std::string create_json_string(const Property& property) {
-  std::string constraints_json_string;
-  for (unsigned i = 0; i < property.Constraints().size(); ++i) {
-    bool first = i == 0;
-    bool last = i == property.Constraints().size() - 1;
-    if (first) {
-      constraints_json_string += "\n";
-    }
-    const auto& constraint = property.Constraints()[i];
-    std::string constraint_json_string = format(R"(    {{
-      "name": "{}",
-      "type": "{}"
-    }}{})", constraint.name, constraint.type.ToString(), (last  ? "" : ",\n"));
-    constraints_json_string += constraint_json_string;
-    if (last) {
-      constraints_json_string += "\n  ";
-    }
-  }
-
-  return format(R"({{
-  "constraints": [{}],
-  "name": "{}",
-  "type": "{}"
-}})", constraints_json_string, property.name, property.type.ToString());
-}
-inline json create_json(const Property& property) {
-  return json::parse(create_json_string(property));
-}
 
 TEST(SchemaPropertyConstraintSerializationTests, ToJsonTest) {
   PropertyConstraint empty_constraint("", ConstraintType::kNone);

--- a/test/translator/schema/property_serialization_test.cpp
+++ b/test/translator/schema/property_serialization_test.cpp
@@ -26,6 +26,35 @@ inline json create_json(const PropertyConstraint& constraint) {
   return json::parse(create_json_string(constraint));
 }
 
+inline std::string create_json_string(const Property& property) {
+  std::string constraints_json_string;
+  for (unsigned i = 0; i < property.Constraints().size(); ++i) {
+    bool first = i == 0;
+    bool last = i == property.Constraints().size() - 1;
+    if (first) {
+      constraints_json_string += "\n";
+    }
+    const auto& constraint = property.Constraints()[i];
+    std::string constraint_json_string = format(R"(    {{
+      "name": "{}",
+      "type": "{}"
+    }}{})", constraint.name, constraint.type.ToString(), (last  ? "" : ",\n"));
+    constraints_json_string += constraint_json_string;
+    if (last) {
+      constraints_json_string += "\n  ";
+    }
+  }
+
+  return format(R"({{
+  "constraints": [{}],
+  "name": "{}",
+  "type": "{}"
+}})", constraints_json_string, property.name, property.type.ToString());
+}
+inline json create_json(const Property& property) {
+  return json::parse(create_json_string(property));
+}
+
 TEST(SchemaPropertyConstraintSerializationTests, ToJsonTest) {
   PropertyConstraint empty_constraint("", ConstraintType::kNone);
   ObjectToJsonTestBody<PropertyConstraint>(empty_constraint, create_json_string(empty_constraint));
@@ -39,4 +68,20 @@ TEST(SchemaPropertyConstraintSerializationTests, FromJsonTest)  {
 
   PropertyConstraint constraint("from_json_constraint", ConstraintType::kUniqueness);
   ObjectFromJsonTestBody<PropertyConstraint>(create_json(constraint), constraint);
+}
+
+TEST(SchemaPropertySerializationTests, ToJsonTest) {
+  Property id_property("id", PropertyType::kInteger);
+  ObjectToJsonTestBody<Property>(id_property, create_json_string(id_property));
+
+  id_property.AddConstraint(PropertyConstraint("pk_constraint_0", ConstraintType::kUniqueness));
+  id_property.AddConstraint(PropertyConstraint("pk_constraint_1", ConstraintType::kExistence));
+  ObjectToJsonTestBody<Property>(id_property, create_json_string(id_property));
+}
+TEST(SchemaPropertySerializationTests, FromJsonTest)  {
+  Property name_property("name", PropertyType::kString);
+  ObjectFromJsonTestBody<Property>(create_json(name_property), name_property);
+
+  name_property.AddConstraint(PropertyConstraint("constraint_name", ConstraintType::kExistence));
+  ObjectFromJsonTestBody<Property>(create_json(name_property), name_property);
 }

--- a/test/translator/schema/relationship_serialization_test.cpp
+++ b/test/translator/schema/relationship_serialization_test.cpp
@@ -1,0 +1,25 @@
+#include "gtest/gtest.h"
+
+#include "nlohmann/json.hpp"
+
+#include "SCC/fixtures_common/serialization.h"
+#include "SCC/translator/schema/relationship.h"
+
+using namespace scc::translator::schema;
+using namespace testing;
+using nlohmann::json;
+
+TEST(SchemaApplyConditionSerializationTests, ToJsonTest) {
+  ApplyCondition empty_condition;
+  ObjectToJsonTestBody(empty_condition, create_json_string(empty_condition));
+
+  ApplyCondition condition(5, 8);
+  ObjectToJsonTestBody(condition, create_json_string(condition));
+}
+TEST(SchemaApplyConditionSerializationTests, FromJsonTest)  {
+  ApplyCondition empty_condition;
+  ObjectFromJsonTestBody(create_json(empty_condition), empty_condition);
+
+  ApplyCondition condition(4, 2);
+  ObjectFromJsonTestBody(create_json(condition), condition);
+}

--- a/test/translator/schema/relationship_serialization_test.cpp
+++ b/test/translator/schema/relationship_serialization_test.cpp
@@ -23,3 +23,25 @@ TEST(SchemaApplyConditionSerializationTests, FromJsonTest)  {
   ApplyCondition condition(4, 2);
   ObjectFromJsonTestBody(create_json(condition), condition);
 }
+
+TEST(SchemaRelationshipSerializationTests, ToJsonTest) {
+  Relationship empty_relationship;
+  ObjectToJsonTestBody(empty_relationship, create_json_string(empty_relationship));
+
+  Relationship relationship("LOVES", "Maxim", "Katya");
+  ObjectToJsonTestBody(relationship, create_json_string(relationship));
+
+  relationship.AddCondition(ApplyCondition(1, 2));
+  relationship.AddCondition(ApplyCondition(5, 7));
+  ObjectToJsonTestBody(relationship, create_json_string(relationship));
+}
+TEST(SchemaRelationshipSerializationTests, FromJsonTest)  {
+  Relationship empty_relationship;
+  ObjectFromJsonTestBody(create_json(empty_relationship), empty_relationship);
+
+  Relationship relationship("DIRECTED", "Nolan", "Batman");
+  ObjectFromJsonTestBody(create_json(relationship), relationship);
+
+  relationship.AddCondition(ApplyCondition(9, 0));
+  ObjectFromJsonTestBody(create_json(relationship), relationship);
+}

--- a/test/translator/schema/relationship_serialization_test.cpp
+++ b/test/translator/schema/relationship_serialization_test.cpp
@@ -11,37 +11,37 @@ using nlohmann::json;
 
 TEST(SchemaApplyConditionSerializationTests, ToJsonTest) {
   ApplyCondition empty_condition;
-  ObjectToJsonTestBody(empty_condition, create_json_string(empty_condition));
+  ObjectToJsonTestBody<ApplyCondition>(empty_condition, create_json_string(empty_condition));
 
   ApplyCondition condition(5, 8);
-  ObjectToJsonTestBody(condition, create_json_string(condition));
+  ObjectToJsonTestBody<ApplyCondition>(condition, create_json_string(condition));
 }
 TEST(SchemaApplyConditionSerializationTests, FromJsonTest)  {
   ApplyCondition empty_condition;
-  ObjectFromJsonTestBody(create_json(empty_condition), empty_condition);
+  ObjectFromJsonTestBody<ApplyCondition>(create_json(empty_condition), empty_condition);
 
   ApplyCondition condition(4, 2);
-  ObjectFromJsonTestBody(create_json(condition), condition);
+  ObjectFromJsonTestBody<ApplyCondition>(create_json(condition), condition);
 }
 
 TEST(SchemaRelationshipSerializationTests, ToJsonTest) {
   Relationship empty_relationship;
-  ObjectToJsonTestBody(empty_relationship, create_json_string(empty_relationship));
+  ObjectToJsonTestBody<Relationship>(empty_relationship, create_json_string(empty_relationship));
 
   Relationship relationship("LOVES", "Maxim", "Katya");
-  ObjectToJsonTestBody(relationship, create_json_string(relationship));
+  ObjectToJsonTestBody<Relationship>(relationship, create_json_string(relationship));
 
   relationship.AddCondition(ApplyCondition(1, 2));
   relationship.AddCondition(ApplyCondition(5, 7));
-  ObjectToJsonTestBody(relationship, create_json_string(relationship));
+  ObjectToJsonTestBody<Relationship>(relationship, create_json_string(relationship));
 }
 TEST(SchemaRelationshipSerializationTests, FromJsonTest)  {
   Relationship empty_relationship;
-  ObjectFromJsonTestBody(create_json(empty_relationship), empty_relationship);
+  ObjectFromJsonTestBody<Relationship>(create_json(empty_relationship), empty_relationship);
 
   Relationship relationship("DIRECTED", "Nolan", "Batman");
-  ObjectFromJsonTestBody(create_json(relationship), relationship);
+  ObjectFromJsonTestBody<Relationship>(create_json(relationship), relationship);
 
   relationship.AddCondition(ApplyCondition(9, 0));
-  ObjectFromJsonTestBody(create_json(relationship), relationship);
+  ObjectFromJsonTestBody<Relationship>(create_json(relationship), relationship);
 }

--- a/test/translator/schema/schema_serialization_test.cpp
+++ b/test/translator/schema/schema_serialization_test.cpp
@@ -1,0 +1,107 @@
+#include "gtest/gtest.h"
+
+#include "nlohmann/json.hpp"
+
+#include "SCC/fixtures_common/serialization.h"
+#include "SCC/translator/cypher/graph/constraint_types.h"
+#include "SCC/translator/cypher/graph/property_types.h"
+#include "SCC/translator/schema/node.h"
+#include "SCC/translator/schema/property.h"
+#include "SCC/translator/schema/relationship.h"
+#include "SCC/translator/schema/schema.h"
+
+using namespace scc::translator::schema;
+using namespace testing;
+using nlohmann::json;
+using scc::translator::cypher::ConstraintType;
+using scc::translator::cypher::PropertyType;
+
+Node create_section_node() {
+  Node section("Section");
+
+  PropertyConstraint section_id_unique("unique_section", ConstraintType::kUniqueness);
+  PropertyConstraint section_id_not_null("not_null_section", ConstraintType::kExistence);
+  Property section_id("section_id", PropertyType::kInteger,
+                      {section_id_unique, section_id_not_null});
+  section.AddProperty(section_id);
+
+  Property section_name("name", PropertyType::kString);
+  section.AddProperty(section_name);
+
+  return section;
+}
+Node create_report_node() {
+  Node report("Report");
+
+  PropertyConstraint report_id_unique("unique_report", ConstraintType::kUniqueness);
+  PropertyConstraint report_id_not_null("not_null_report", ConstraintType::kExistence);
+  Property report_id("report_id", PropertyType::kInteger,
+                          {report_id_unique, report_id_not_null});
+  report.AddProperty(report_id);
+
+  Property report_title("title", PropertyType::kString);
+  report.AddProperty(report_title);
+
+  Property report_section_id("section_id", PropertyType::kInteger);
+  report.AddProperty(report_section_id);
+
+  return report;
+}
+Node create_participant_node() {
+  Node participant("Participant");
+
+  PropertyConstraint participant_id_unique("unique_participant", ConstraintType::kUniqueness);
+  PropertyConstraint participant_id_not_null("not_null_participant", ConstraintType::kExistence);
+  Property participant_id("participant_id", PropertyType::kInteger,
+                          {participant_id_unique, participant_id_not_null});
+  participant.AddProperty(participant_id);
+
+  PropertyConstraint participant_name_unique("unique_name", ConstraintType::kUniqueness);
+  Property participant_name("name", PropertyType::kString);
+  participant.AddProperty(participant_name);
+
+  Property participant_age("age", PropertyType::kInteger);
+  participant.AddProperty(participant_age);
+
+  Property participant_report_id("report_id", PropertyType::kInteger);
+  participant.AddProperty(participant_report_id);
+
+  return participant;
+}
+Relationship create_report_to_section_relationship() {
+  Relationship relationship("REPORTED_ON", "Report", "Section");
+  relationship.AddCondition(ApplyCondition(2, 0));
+  return relationship;
+}
+Relationship create_participant_to_report_relationship() {
+  Relationship relationship("REPORTS",  "Participant",  "Report");
+  relationship.AddCondition(ApplyCondition(3, 0));
+  return relationship;
+}
+Schema create_test_schema() {
+  Schema schema("Conference");
+
+  schema.AddNode(create_section_node());
+  schema.AddNode(create_report_node());
+  schema.AddNode(create_participant_node());
+
+  schema.AddRelationship(create_report_to_section_relationship());
+  schema.AddRelationship(create_participant_to_report_relationship());
+
+  return schema;
+}
+
+TEST(SchemaSerializationTests, ToJsonTest) {
+  Schema empty_schema;
+  ObjectToJsonTestBody<Schema>(empty_schema, create_json_string(empty_schema));
+
+  Schema schema = create_test_schema();
+  ObjectToJsonTestBody<Schema>(schema, create_json_string(schema));
+}
+TEST(SchemaSerializationTests, FromJsonTest)  {
+  Schema empty_schema;
+  ObjectFromJsonTestBody<Schema>(create_json(empty_schema), empty_schema);
+
+  Schema schema = create_test_schema();
+  ObjectFromJsonTestBody<Schema>(create_json(schema), schema);
+}


### PR DESCRIPTION
Closes #55.

Now, two modes of translation are supported:
- Schema migration queries (DDL);
- Data migration queries (DML).

When we translate the SQL schema (`scc --translate-schema ...`), we will get `.json` file as result with graph structure. This JSON file is a serialized `Schema` class with nodes and relationships, property constraints and relationships apply conditions.

When we translate the SQL DML queries (`scc --translate-data ...`) we will get `.cql` file with the Cypher queries, which create data in the Neo4j database using graph structure from the previous translation step.