### PR TITLE
[#61] Add more unit tests for enums

### DIFF
--- a/src/ast/stmt_types.cpp
+++ b/src/ast/stmt_types.cpp
@@ -101,6 +101,8 @@ StmtType::StmtType(const std::string_view& str_type) {
     this->value_ = kPrimaryKey;
   else if (type == kST_FOREIGN_KEY)
     this->value_ = kForeignKey;
+  else if (type == kST_NAME)
+    this->value_ = kName;
   else if (type == kST_IDENTIFIER)
     this->value_ = kIdentifier;
   else if (type == kST_DOT_DELIMITER)

--- a/test/ast/data_types_test.cpp
+++ b/test/ast/data_types_test.cpp
@@ -70,7 +70,7 @@ TEST(DataTypeCtorTests, MixedCaseStringTest) {
   CreateFromStringTestBody<DataType>("STRINg", DataType::kString);
 }
 
-TEST(DataTypeoStringTests, ToStringTest) {
+TEST(DataTypeStringTests, ToStringTest) {
   ToStringTestBody<DataType>(DataType::kNone, kDT_None);
   ToStringTestBody<DataType>(DataType::kRoot, kDT_Root);
   ToStringTestBody<DataType>(DataType::kService, kDT_Service);

--- a/test/ast/data_types_test.cpp
+++ b/test/ast/data_types_test.cpp
@@ -1,28 +1,21 @@
-#include <sstream>
-#include <stdexcept>
+#include <compare>
 
 #include "gtest/gtest.h"
 
 #include "SCC/ast/data_types.h"
+#include "SCC/fixtures_common/enum.h"
 
 using namespace scc::ast;
 using namespace testing;
 
+using UChar = unsigned char;
+
 TEST(DataTypeValueEnumTests, IsUnsignedCharTest) {
-  int N_0 = 0;
-  EXPECT_EQ((unsigned char) N_0, DataType::Value(N_0));
-
-  int N_neg1 = -1;
-  EXPECT_EQ((unsigned char) N_neg1, DataType::Value(N_neg1));
-
-  int N_50 = 50;
-  EXPECT_EQ((unsigned char) N_50, DataType::Value(N_50));
-
-  int N_128 = 128;
-  EXPECT_EQ((unsigned char) N_128, DataType::Value(N_128));
-
-  int N_256 = 256;
-  EXPECT_EQ((unsigned char) N_256, DataType::Value(N_256));
+  CastEnumTestBody<UChar, DataType::Value>(0);
+  CastEnumTestBody<UChar, DataType::Value>(-1);
+  CastEnumTestBody<UChar, DataType::Value>(50);
+  CastEnumTestBody<UChar, DataType::Value>(128);
+  CastEnumTestBody<UChar, DataType::Value>(256);
 }
 
 TEST(DataTypeCtorTests, DefaultValueTest) {
@@ -31,71 +24,70 @@ TEST(DataTypeCtorTests, DefaultValueTest) {
 }
 
 TEST(DataTypeCtorTests, ValueTest) {
-  EXPECT_EQ(DataType::kNone, (DataType::Value) DataType(DataType::kNone));
-  EXPECT_EQ(DataType::kRoot, (DataType::Value) DataType(DataType::kRoot));
-  EXPECT_EQ(DataType::kInt, (DataType::Value) DataType(DataType::kInt));
-  EXPECT_EQ(DataType::kBracket, (DataType::Value) DataType(DataType::kBracket));
-  EXPECT_EQ(DataType::kString, (DataType::Value) DataType(DataType::kString));
+  CastWrapperToValueTestBody<DataType, DataType::Value>(DataType::kNone);
+  CastWrapperToValueTestBody<DataType, DataType::Value>(DataType::kRoot);
+  CastWrapperToValueTestBody<DataType, DataType::Value>(DataType::kInt);
+  CastWrapperToValueTestBody<DataType, DataType::Value>(DataType::kBracket);
+  CastWrapperToValueTestBody<DataType, DataType::Value>(DataType::kString);
 }
 
 TEST(DataTypeCtorTests, InvalidValueTest) {
-  EXPECT_THROW(DataType(DataType::Value(-1)), std::invalid_argument);
-  EXPECT_THROW(DataType(DataType::Value(100)), std::invalid_argument);
-}
-
-TEST(DataTypeCtorTests, StringValueTest) {
-  DataType root(kDT_Root);
-  EXPECT_EQ(DataType::kRoot, (DataType::Value) root);
-
-  DataType punctuation(kDT_Punctuation);
-  EXPECT_EQ(DataType::kPunctuation, (DataType::Value) punctuation);
-
-  DataType mixed_case_service("serViCE");
-  EXPECT_EQ(DataType::kService, (DataType::Value) mixed_case_service);
+  CreateWithInvalidArgumentTestBody<DataType, DataType::Value>(-1);
+  CreateWithInvalidArgumentTestBody<DataType, DataType::Value>(100);
 }
 
 TEST(DataTypeCtorTests, InvalidStringValueTest) {
-  EXPECT_THROW(DataType("something wrong"), std::invalid_argument);
-  EXPECT_THROW(DataType("oa8sdg"), std::invalid_argument);
-  EXPECT_THROW(DataType("ro0t"), std::invalid_argument);
-  EXPECT_THROW(DataType("non"), std::invalid_argument);
-  EXPECT_THROW(DataType("braket"), std::invalid_argument);
+  CreateWithInvalidArgumentTestBody<DataType, DataType::Value>("something wrong");
+  CreateWithInvalidArgumentTestBody<DataType, DataType::Value>("oa8sdg");
+  CreateWithInvalidArgumentTestBody<DataType, DataType::Value>("ro0t");
+  CreateWithInvalidArgumentTestBody<DataType, DataType::Value>("non");
+  CreateWithInvalidArgumentTestBody<DataType, DataType::Value>("braket");
+}
+
+TEST(DataTypeCtorTests, StringValueTest) {
+  CreateFromStringTestBody<DataType>(kDT_None, DataType::kNone);
+  CreateFromStringTestBody<DataType>(kDT_Root, DataType::kRoot);
+  CreateFromStringTestBody<DataType>(kDT_Service, DataType::kService);
+  CreateFromStringTestBody<DataType>(kDT_Int, DataType::kInt);
+  CreateFromStringTestBody<DataType>(kDT_Float, DataType::kFloat);
+  CreateFromStringTestBody<DataType>(kDT_Bracket, DataType::kBracket);
+  CreateFromStringTestBody<DataType>(kDT_Punctuation, DataType::kPunctuation);
+  CreateFromStringTestBody<DataType>(kDT_Operator, DataType::kOperator);
+  CreateFromStringTestBody<DataType>(kDT_Word, DataType::kWord);
+  CreateFromStringTestBody<DataType>(kDT_String, DataType::kString);
+}
+
+TEST(DataTypeCtorTests, MixedCaseStringTest) {
+  CreateFromStringTestBody<DataType>("NoNe", DataType::kNone);
+  CreateFromStringTestBody<DataType>("RoOT", DataType::kRoot);
+  CreateFromStringTestBody<DataType>("service", DataType::kService);
+  CreateFromStringTestBody<DataType>("iNT", DataType::kInt);
+  CreateFromStringTestBody<DataType>("flOAT", DataType::kFloat);
+  CreateFromStringTestBody<DataType>("BRAcket", DataType::kBracket);
+  CreateFromStringTestBody<DataType>("PuNcTuAtIoN", DataType::kPunctuation);
+  CreateFromStringTestBody<DataType>("OperaTOR", DataType::kOperator);
+  CreateFromStringTestBody<DataType>("WORD", DataType::kWord);
+  CreateFromStringTestBody<DataType>("STRINg", DataType::kString);
 }
 
 TEST(DataTypeoStringTests, ToStringTest) {
-  EXPECT_EQ(kDT_None, DataType(DataType::kNone).ToString());
-  EXPECT_EQ(kDT_Root, DataType(DataType::kRoot).ToString());
-  EXPECT_EQ(kDT_Int, DataType(DataType::kInt).ToString());
-  EXPECT_EQ(kDT_Service, DataType(DataType::kService).ToString());
-  EXPECT_EQ(kDT_Word, DataType(DataType::kWord).ToString());
-}
-
-TEST(DataTypeCastTests, CastToValueTest) {
-  DataType bracket(DataType::kBracket);
-  auto bracket_val = (DataType::Value) bracket;
-  EXPECT_EQ(DataType::kBracket, bracket_val);
-
-  DataType punctuation(DataType::kPunctuation);
-  auto punctuation_val = (DataType::Value) punctuation;
-  EXPECT_EQ(DataType::kPunctuation, punctuation_val);
+  ToStringTestBody<DataType>(DataType::kNone, kDT_None);
+  ToStringTestBody<DataType>(DataType::kRoot, kDT_Root);
+  ToStringTestBody<DataType>(DataType::kService, kDT_Service);
+  ToStringTestBody<DataType>(DataType::kInt, kDT_Int);
+  ToStringTestBody<DataType>(DataType::kFloat, kDT_Float);
+  ToStringTestBody<DataType>(DataType::kBracket, kDT_Bracket);
+  ToStringTestBody<DataType>(DataType::kPunctuation, kDT_Punctuation);
+  ToStringTestBody<DataType>(DataType::kOperator, kDT_Operator);
+  ToStringTestBody<DataType>(DataType::kWord, kDT_Word);
+  ToStringTestBody<DataType>(DataType::kString, kDT_String);
 }
 
 TEST(DataTypeOperatorsTests, OutputTest) {
-  std::ostringstream oss_none;
-  oss_none << DataType(DataType::kNone);
-  EXPECT_EQ(kDT_None, oss_none.str());
-
-  std::ostringstream oss_punctuation;
-  oss_punctuation << DataType(DataType::kPunctuation);
-  EXPECT_EQ(kDT_Punctuation, oss_punctuation.str());
-
-  std::ostringstream oss_operator;
-  oss_operator << DataType(DataType::kOperator);
-  EXPECT_EQ(kDT_Operator, oss_operator.str());
-
-  std::ostringstream oss_string;
-  oss_string << DataType(DataType::kString);
-  EXPECT_EQ(kDT_String, oss_string.str());
+  OutputTestBody<DataType, DataType::Value>(DataType::kNone, kDT_None);
+  OutputTestBody<DataType, DataType::Value>(DataType::kPunctuation, kDT_Punctuation);
+  OutputTestBody<DataType, DataType::Value>(DataType::kOperator, kDT_Operator);
+  OutputTestBody<DataType, DataType::Value>(DataType::kString, kDT_String);
 }
 
 TEST(DataTypeOperatorsTests, CompareTwoEqualTypesTest) {

--- a/test/ast/stmt_types_test.cpp
+++ b/test/ast/stmt_types_test.cpp
@@ -1,28 +1,21 @@
-#include <sstream>
-#include <stdexcept>
+#include <compare>
 
 #include "gtest/gtest.h"
 
 #include "SCC/ast/stmt_types.h"
+#include "SCC/fixtures_common/enum.h"
 
 using namespace scc::ast;
 using namespace testing;
 
+using UChar = unsigned char;
+
 TEST(StmtTypeValueEnumTests, IsUnsignedCharTest) {
-  int N_0 = 0;
-  EXPECT_EQ((unsigned char) N_0, StmtType::Value(N_0));
-
-  int N_neg1 = -1;
-  EXPECT_EQ((unsigned char) N_neg1, StmtType::Value(N_neg1));
-
-  int N_50 = 50;
-  EXPECT_EQ((unsigned char) N_50, StmtType::Value(N_50));
-
-  int N_128 = 128;
-  EXPECT_EQ((unsigned char) N_128, StmtType::Value(N_128));
-
-  int N_256 = 256;
-  EXPECT_EQ((unsigned char) N_256, StmtType::Value(N_256));
+  CastEnumTestBody<UChar, StmtType::Value>(0);
+  CastEnumTestBody<UChar, StmtType::Value>(-1);
+  CastEnumTestBody<UChar, StmtType::Value>(50);
+  CastEnumTestBody<UChar, StmtType::Value>(128);
+  CastEnumTestBody<UChar, StmtType::Value>(256);
 }
 
 TEST(StmtTypeCtorTests, DefaultValueTest) {
@@ -31,76 +24,194 @@ TEST(StmtTypeCtorTests, DefaultValueTest) {
 }
 
 TEST(StmtTypeCtorTests, ValueTest) {
-  EXPECT_EQ(StmtType::kNone, (StmtType::Value) StmtType(StmtType::kNone));
-  EXPECT_EQ(StmtType::kProgram, (StmtType::Value) StmtType(StmtType::kProgram));
-  EXPECT_EQ(StmtType::kAlterTableStmt, (StmtType::Value) StmtType(StmtType::kAlterTableStmt));
-  EXPECT_EQ(StmtType::kReferencesKW, (StmtType::Value) StmtType(StmtType::kReferencesKW));
-  EXPECT_EQ(StmtType::kVarcharType, (StmtType::Value) StmtType(StmtType::kVarcharType));
+  CastWrapperToValueTestBody<StmtType, StmtType::Value>(StmtType::kNone);
+  CastWrapperToValueTestBody<StmtType, StmtType::Value>(StmtType::kCreateDatabaseStmt);
+  CastWrapperToValueTestBody<StmtType, StmtType::Value>(StmtType::kAlterAddList);
+  CastWrapperToValueTestBody<StmtType, StmtType::Value>(StmtType::kUpdateColumn);
+  CastWrapperToValueTestBody<StmtType, StmtType::Value>(StmtType::kName);
 }
 
 TEST(StmtTypeCtorTests, InvalidValueTest) {
-  EXPECT_THROW(StmtType(StmtType::Value(-1)), std::invalid_argument);
-  EXPECT_THROW(StmtType(StmtType::Value(100)), std::invalid_argument);
-}
-
-TEST(StmtTypeCtorTests, StringValueTest) {
-  StmtType column_def(kST_COLUMN_DEF);
-  EXPECT_EQ(StmtType::kColumnDef, (StmtType::Value) column_def);
-
-  StmtType reference(kST_REFERENCES_KW);
-  EXPECT_EQ(StmtType::kReferencesKW, (StmtType::Value) reference);
-
-  StmtType mixed_case_expression("expREssION");
-  EXPECT_EQ(StmtType::kExpression, (StmtType::Value) mixed_case_expression);
+  CreateWithInvalidArgumentTestBody<StmtType, StmtType::Value>(-1);
+  CreateWithInvalidArgumentTestBody<StmtType, StmtType::Value>(60);
 }
 
 TEST(StmtTypeCtorTests, InvalidStringValueTest) {
-  EXPECT_THROW(StmtType("piece of wrong stmt"), std::invalid_argument);
-  EXPECT_THROW(StmtType("lksdf7"), std::invalid_argument);
-  EXPECT_THROW(StmtType("dr0p list"), std::invalid_argument);
-  EXPECT_THROW(StmtType("non"), std::invalid_argument);
-  EXPECT_THROW(StmtType("1nsert"), std::invalid_argument);
+  CreateWithInvalidArgumentTestBody<StmtType, StmtType::Value>("09a8sdg");
+  CreateWithInvalidArgumentTestBody<StmtType, StmtType::Value>("n0ne");
+  CreateWithInvalidArgumentTestBody<StmtType, StmtType::Value>("updates");
 }
 
-TEST(StmtTypeoStringTests, ToStringTest) {
-  EXPECT_EQ(kST_NONE, StmtType(StmtType::kNone).ToString());
-  EXPECT_EQ(kST_TABLE_DEF, StmtType(StmtType::kTableDef).ToString());
-  EXPECT_EQ(kST_UPDATE, StmtType(StmtType::kUpdateStmt).ToString());
-  EXPECT_EQ(kST_DOT_DELIMITER, StmtType(StmtType::kDotDelimiter).ToString());
-  EXPECT_EQ(kST_VARCHAR_TYPE, StmtType(StmtType::kVarcharType).ToString());
+TEST(StmtTypeCtorTests, StringValueTest) {
+  CreateFromStringTestBody<StmtType>(kST_NONE, StmtType::kNone);
+  CreateFromStringTestBody<StmtType>(kST_PROGRAM, StmtType::kProgram);
+  CreateFromStringTestBody<StmtType>(kST_QUERY, StmtType::kQuery);
+  CreateFromStringTestBody<StmtType>(kST_DDL_STMT, StmtType::kDdlStmt);
+  CreateFromStringTestBody<StmtType>(kST_DML_STMT, StmtType::kDmlStmt);
+
+  CreateFromStringTestBody<StmtType>(kST_ALTER_TABLE, StmtType::kAlterTableStmt);
+  CreateFromStringTestBody<StmtType>(kST_CREATE_DATABASE, StmtType::kCreateDatabaseStmt);
+  CreateFromStringTestBody<StmtType>(kST_CREATE_TABLE, StmtType::kCreateTableStmt);
+  CreateFromStringTestBody<StmtType>(kST_DROP_DATABASE, StmtType::kDropDatabaseStmt);
+  CreateFromStringTestBody<StmtType>(kST_DROP_TABLE, StmtType::kDropTableStmt);
+
+  CreateFromStringTestBody<StmtType>(kST_TABLE_DEF, StmtType::kTableDef);
+  CreateFromStringTestBody<StmtType>(kST_COLUMN_DEF, StmtType::kColumnDef);
+  CreateFromStringTestBody<StmtType>(kST_TABLE_CONSTRAINT, StmtType::kTableConstraint);
+  CreateFromStringTestBody<StmtType>(kST_ALTER_ACTION_ADD, StmtType::kAlterActionAdd);
+  CreateFromStringTestBody<StmtType>(kST_ALTER_ADD_LIST, StmtType::kAlterAddList);
+  CreateFromStringTestBody<StmtType>(kST_ALTER_ACTION_DROP, StmtType::kAlterActionDrop);
+  CreateFromStringTestBody<StmtType>(kST_ALTER_DROP_LIST, StmtType::kAlterDropList);
+  CreateFromStringTestBody<StmtType>(kST_DROP_CONSTRAINT, StmtType::kDropConstraint);
+  CreateFromStringTestBody<StmtType>(kST_DROP_COLUMN, StmtType::kDropColumn);
+
+  CreateFromStringTestBody<StmtType>(kST_DELETE, StmtType::kDeleteStmt);
+  CreateFromStringTestBody<StmtType>(kST_INSERT, StmtType::kInsertStmt);
+  CreateFromStringTestBody<StmtType>(kST_UPDATE, StmtType::kUpdateStmt);
+
+  CreateFromStringTestBody<StmtType>(kST_UPDATE_COLUMN, StmtType::kUpdateColumn);
+
+  CreateFromStringTestBody<StmtType>(kST_CONDITION, StmtType::kCondition);
+  CreateFromStringTestBody<StmtType>(kST_OR_CONDITION, StmtType::kORCondition);
+  CreateFromStringTestBody<StmtType>(kST_AND_CONDITION, StmtType::kANDCondition);
+  CreateFromStringTestBody<StmtType>(kST_NOT_CONDITION, StmtType::kNOTCondition);
+  CreateFromStringTestBody<StmtType>(kST_PREDICATE, StmtType::kPredicate);
+  CreateFromStringTestBody<StmtType>(kST_EXPRESSION, StmtType::kExpression);
+
+  CreateFromStringTestBody<StmtType>(kST_MATH_EXPRESSION, StmtType::kMathExpression);
+  CreateFromStringTestBody<StmtType>(kST_SUM, StmtType::kSum);
+  CreateFromStringTestBody<StmtType>(kST_PRODUCT, StmtType::kProduct);
+  CreateFromStringTestBody<StmtType>(kST_POWER, StmtType::kPower);
+  CreateFromStringTestBody<StmtType>(kST_VALUE, StmtType::kValue);
+
+  CreateFromStringTestBody<StmtType>(kST_OR_OPERATOR, StmtType::kOROperator);
+  CreateFromStringTestBody<StmtType>(kST_AND_OPERATOR, StmtType::kANDOperator);
+  CreateFromStringTestBody<StmtType>(kST_NOT_OPERATOR, StmtType::kNOTOperator);
+
+  CreateFromStringTestBody<StmtType>(kST_PRIMARY_KEY, StmtType::kPrimaryKey);
+  CreateFromStringTestBody<StmtType>(kST_FOREIGN_KEY, StmtType::kForeignKey);
+  CreateFromStringTestBody<StmtType>(kST_NAME, StmtType::kName);
+  CreateFromStringTestBody<StmtType>(kST_IDENTIFIER, StmtType::kIdentifier);
+  CreateFromStringTestBody<StmtType>(kST_DOT_DELIMITER, StmtType::kDotDelimiter);
+  CreateFromStringTestBody<StmtType>(kST_COMMA_DELIMITER, StmtType::kCommaDelimiter);
+  CreateFromStringTestBody<StmtType>(kST_SEMICOLON_DELIMITER, StmtType::kSemicolonDelimiter);
+
+  CreateFromStringTestBody<StmtType>(kST_CONSTRAINT_KW, StmtType::kConstraintKW);
+  CreateFromStringTestBody<StmtType>(kST_COLUMN_KW, StmtType::kColumnKW);
+  CreateFromStringTestBody<StmtType>(kST_REFERENCES_KW, StmtType::kReferencesKW);
+  CreateFromStringTestBody<StmtType>(kST_ADD_KW, StmtType::kAddKW);
+  CreateFromStringTestBody<StmtType>(kST_DROP_KW, StmtType::kDropKW);
+  CreateFromStringTestBody<StmtType>(kST_INTO_KW, StmtType::kIntoKW);
+  CreateFromStringTestBody<StmtType>(kST_SET_KW, StmtType::kSetKW);
+  CreateFromStringTestBody<StmtType>(kST_FROM_KW, StmtType::kFromKW);
+  CreateFromStringTestBody<StmtType>(kST_WHERE_KW, StmtType::kWhereKW);
+  CreateFromStringTestBody<StmtType>(kST_VALUES_KW, StmtType::kValuesKW);
+
+  CreateFromStringTestBody<StmtType>(kST_INT_TYPE, StmtType::kIntType);
+  CreateFromStringTestBody<StmtType>(kST_INTEGER_TYPE, StmtType::kIntType);
+  CreateFromStringTestBody<StmtType>(kST_FLOAT_TYPE, StmtType::kFloatType);
+  CreateFromStringTestBody<StmtType>(kST_CHAR_TYPE, StmtType::kCharType);
+  CreateFromStringTestBody<StmtType>(kST_VARCHAR_TYPE, StmtType::kVarcharType);
+
+  CreateFromStringTestBody<StmtType>(kST_NULL_VALUE, StmtType::kNullValue);
+  CreateFromStringTestBody<StmtType>(kST_UNKNOWN_VALUE, StmtType::kUnknownValue);
 }
 
-TEST(StmtTypeCastTests, CastToValueTest) {
-  StmtType alter_table_stmt(StmtType::kAlterTableStmt);
-  auto alter_table_stmt_val = (StmtType::Value) alter_table_stmt;
-  EXPECT_EQ(StmtType::kAlterTableStmt, alter_table_stmt_val);
+TEST(StmtTypeCtorTests, MixedCaseStringTest) {
+  CreateFromStringTestBody<StmtType>("NOne", StmtType::kNone);
+  CreateFromStringTestBody<StmtType>("DROP database", StmtType::kDropDatabaseStmt);
+  CreateFromStringTestBody<StmtType>("alTER drOP List", StmtType::kAlterDropList);
+  CreateFromStringTestBody<StmtType>("product", StmtType::kProduct);
+  CreateFromStringTestBody<StmtType>("SEMICOLON DELIMITER", StmtType::kSemicolonDelimiter);
+  CreateFromStringTestBody<StmtType>("SeT", StmtType::kSetKW);
+  CreateFromStringTestBody<StmtType>("FloAT", StmtType::kFloatType);
+}
 
-  StmtType drop_table_stmt(StmtType::kDropTableStmt);
-  auto drop_table_stmt_val = (StmtType::Value) drop_table_stmt;
-  EXPECT_EQ(StmtType::kDropTableStmt, drop_table_stmt_val);
+TEST(StmtTypeStringTests, ToStringTest) {
+  ToStringTestBody<StmtType>(StmtType::kNone, kST_NONE);
+  ToStringTestBody<StmtType>(StmtType::kProgram, kST_PROGRAM);
+  ToStringTestBody<StmtType>(StmtType::kQuery, kST_QUERY);
+  ToStringTestBody<StmtType>(StmtType::kDdlStmt, kST_DDL_STMT);
+  ToStringTestBody<StmtType>(StmtType::kDmlStmt, kST_DML_STMT);
+
+  ToStringTestBody<StmtType>(StmtType::kAlterTableStmt, kST_ALTER_TABLE);
+  ToStringTestBody<StmtType>(StmtType::kCreateDatabaseStmt, kST_CREATE_DATABASE);
+  ToStringTestBody<StmtType>(StmtType::kCreateTableStmt, kST_CREATE_TABLE);
+  ToStringTestBody<StmtType>(StmtType::kDropDatabaseStmt, kST_DROP_DATABASE);
+  ToStringTestBody<StmtType>(StmtType::kDropTableStmt, kST_DROP_TABLE);
+
+  ToStringTestBody<StmtType>(StmtType::kTableDef, kST_TABLE_DEF);
+  ToStringTestBody<StmtType>(StmtType::kColumnDef, kST_COLUMN_DEF);
+  ToStringTestBody<StmtType>(StmtType::kTableConstraint, kST_TABLE_CONSTRAINT);
+  ToStringTestBody<StmtType>(StmtType::kAlterActionAdd, kST_ALTER_ACTION_ADD);
+  ToStringTestBody<StmtType>(StmtType::kAlterAddList, kST_ALTER_ADD_LIST);
+  ToStringTestBody<StmtType>(StmtType::kAlterActionDrop, kST_ALTER_ACTION_DROP);
+  ToStringTestBody<StmtType>(StmtType::kAlterDropList, kST_ALTER_DROP_LIST);
+  ToStringTestBody<StmtType>(StmtType::kDropConstraint, kST_DROP_CONSTRAINT);
+  ToStringTestBody<StmtType>(StmtType::kDropColumn, kST_DROP_COLUMN);
+
+  ToStringTestBody<StmtType>(StmtType::kDeleteStmt, kST_DELETE);
+  ToStringTestBody<StmtType>(StmtType::kInsertStmt, kST_INSERT);
+  ToStringTestBody<StmtType>(StmtType::kUpdateStmt, kST_UPDATE);
+
+  ToStringTestBody<StmtType>(StmtType::kUpdateColumn, kST_UPDATE_COLUMN);
+
+  ToStringTestBody<StmtType>(StmtType::kCondition, kST_CONDITION);
+  ToStringTestBody<StmtType>(StmtType::kORCondition, kST_OR_CONDITION);
+  ToStringTestBody<StmtType>(StmtType::kANDCondition, kST_AND_CONDITION);
+  ToStringTestBody<StmtType>(StmtType::kNOTCondition, kST_NOT_CONDITION);
+  ToStringTestBody<StmtType>(StmtType::kPredicate, kST_PREDICATE);
+  ToStringTestBody<StmtType>(StmtType::kExpression, kST_EXPRESSION);
+
+  ToStringTestBody<StmtType>(StmtType::kMathExpression, kST_MATH_EXPRESSION);
+  ToStringTestBody<StmtType>(StmtType::kSum, kST_SUM);
+  ToStringTestBody<StmtType>(StmtType::kProduct, kST_PRODUCT);
+  ToStringTestBody<StmtType>(StmtType::kPower, kST_POWER);
+  ToStringTestBody<StmtType>(StmtType::kValue, kST_VALUE);
+
+  ToStringTestBody<StmtType>(StmtType::kOROperator, kST_OR_OPERATOR);
+  ToStringTestBody<StmtType>(StmtType::kANDOperator, kST_AND_OPERATOR);
+  ToStringTestBody<StmtType>(StmtType::kNOTOperator, kST_NOT_OPERATOR);
+
+  ToStringTestBody<StmtType>(StmtType::kPrimaryKey, kST_PRIMARY_KEY);
+  ToStringTestBody<StmtType>(StmtType::kForeignKey, kST_FOREIGN_KEY);
+  ToStringTestBody<StmtType>(StmtType::kName, kST_NAME);
+  ToStringTestBody<StmtType>(StmtType::kIdentifier, kST_IDENTIFIER);
+  ToStringTestBody<StmtType>(StmtType::kDotDelimiter, kST_DOT_DELIMITER);
+  ToStringTestBody<StmtType>(StmtType::kCommaDelimiter, kST_COMMA_DELIMITER);
+  ToStringTestBody<StmtType>(StmtType::kSemicolonDelimiter, kST_SEMICOLON_DELIMITER);
+
+  ToStringTestBody<StmtType>(StmtType::kConstraintKW, kST_CONSTRAINT_KW);
+  ToStringTestBody<StmtType>(StmtType::kColumnKW, kST_COLUMN_KW);
+  ToStringTestBody<StmtType>(StmtType::kReferencesKW, kST_REFERENCES_KW);
+  ToStringTestBody<StmtType>(StmtType::kAddKW, kST_ADD_KW);
+  ToStringTestBody<StmtType>(StmtType::kDropKW, kST_DROP_KW);
+  ToStringTestBody<StmtType>(StmtType::kIntoKW, kST_INTO_KW);
+  ToStringTestBody<StmtType>(StmtType::kSetKW, kST_SET_KW);
+  ToStringTestBody<StmtType>(StmtType::kFromKW, kST_FROM_KW);
+  ToStringTestBody<StmtType>(StmtType::kWhereKW, kST_WHERE_KW);
+  ToStringTestBody<StmtType>(StmtType::kValuesKW, kST_VALUES_KW);
+
+  ToStringTestBody<StmtType>(StmtType::kIntType, kST_INT_TYPE);
+  ToStringTestBody<StmtType>(StmtType::kFloatType, kST_FLOAT_TYPE);
+  ToStringTestBody<StmtType>(StmtType::kCharType, kST_CHAR_TYPE);
+  ToStringTestBody<StmtType>(StmtType::kVarcharType, kST_VARCHAR_TYPE);
+
+  ToStringTestBody<StmtType>(StmtType::kNullValue, kST_NULL_VALUE);
+  ToStringTestBody<StmtType>(StmtType::kUnknownValue, kST_UNKNOWN_VALUE);
 }
 
 TEST(StmtTypeOperatorsTests, OutputTest) {
-  std::ostringstream oss_create_database_stmt;
-  oss_create_database_stmt << StmtType(StmtType::kCreateDatabaseStmt);
-  EXPECT_EQ(kST_CREATE_DATABASE, oss_create_database_stmt.str());
-
-  std::ostringstream oss_alter_drop_list;
-  oss_alter_drop_list << StmtType(StmtType::kAlterDropList);
-  EXPECT_EQ(kST_ALTER_DROP_LIST, oss_alter_drop_list.str());
-
-  std::ostringstream oss_condition;
-  oss_condition << StmtType(StmtType::kCondition);
-  EXPECT_EQ(kST_CONDITION, oss_condition.str());
-
-  std::ostringstream oss_foreign_key;
-  oss_foreign_key << StmtType(StmtType::kForeignKey);
-  EXPECT_EQ(kST_FOREIGN_KEY, oss_foreign_key.str());
+  OutputTestBody<StmtType, StmtType::Value>(StmtType::kNone, kST_NONE);
+  OutputTestBody<StmtType, StmtType::Value>(StmtType::kColumnDef, kST_COLUMN_DEF);
+  OutputTestBody<StmtType, StmtType::Value>(StmtType::kInsertStmt, kST_INSERT);
+  OutputTestBody<StmtType, StmtType::Value>(StmtType::kPredicate, kST_PREDICATE);
+  OutputTestBody<StmtType, StmtType::Value>(StmtType::kIdentifier, kST_IDENTIFIER);
 }
 
 TEST(StmtTypeOperatorsTests, CompareTwoEqualTypesTest) {
-  StmtType first(StmtType::kTableDef);
-  StmtType second(StmtType::kTableDef);
+  StmtType first(StmtType::kQuery);
+  StmtType second(StmtType::kQuery);
 
   EXPECT_TRUE(first == second);
   EXPECT_TRUE(first <= second);
@@ -112,8 +223,8 @@ TEST(StmtTypeOperatorsTests, CompareTwoEqualTypesTest) {
 }
 
 TEST(StmtTypeOperatorsTests, CompareTwoDifferentTypesTest) {
-  StmtType first(StmtType::kIdentifier);
-  StmtType second(StmtType::kFloatType);
+  StmtType first(StmtType::kColumnDef);
+  StmtType second(StmtType::kUpdateStmt);
 
   EXPECT_TRUE(first != second);
   EXPECT_TRUE(first <= second);
@@ -126,8 +237,8 @@ TEST(StmtTypeOperatorsTests, CompareTwoDifferentTypesTest) {
 }
 
 TEST(StmtTypeOperatorsTests, CompareWithEqualValueTest) {
-  StmtType type(StmtType::kPrimaryKey);
-  StmtType::Value value = StmtType::kPrimaryKey;
+  StmtType type(StmtType::kPredicate);
+  StmtType::Value value = StmtType::kPredicate;
 
   EXPECT_TRUE(type == value);
   EXPECT_TRUE(type <= value);
@@ -138,8 +249,8 @@ TEST(StmtTypeOperatorsTests, CompareWithEqualValueTest) {
 }
 
 TEST(StmtTypeOperatorsTests, CompareWithDifferentValueTest) {
-  StmtType type(StmtType::kCreateTableStmt);
-  StmtType::Value value = StmtType::kColumnDef;
+  StmtType type(StmtType::kDotDelimiter);
+  StmtType::Value value = StmtType::kSemicolonDelimiter;
 
   EXPECT_TRUE(type != value);
   EXPECT_TRUE(type <= value);

--- a/test/config/scc_mode_test.cpp
+++ b/test/config/scc_mode_test.cpp
@@ -43,12 +43,12 @@ TEST(SCCModeCtorTests, StringValueTest) {
   CreateFromStringTestBody<SCCMode>(kMode_Daemon, SCCMode::kDaemon);
 }
 
-TEST(DataTypeCtorTests, MixedCaseStringTest) {
+TEST(SCCModeCtorTests, MixedCaseStringTest) {
   CreateFromStringTestBody<SCCMode>("DaeMON", SCCMode::kDaemon);
   CreateFromStringTestBody<SCCMode>("interACTIVE", SCCMode::kInteractive);
 }
 
-TEST(SCCModeoStringTests, ToStringTest) {
+TEST(SCCModeStringTests, ToStringTest) {
   ToStringTestBody<SCCMode>(SCCMode::kDaemon, kMode_Daemon);
   ToStringTestBody<SCCMode>(SCCMode::kInteractive, kMode_Interactive);
 }

--- a/test/config/scc_mode_test.cpp
+++ b/test/config/scc_mode_test.cpp
@@ -1,29 +1,21 @@
 #include <compare>
-#include <sstream>
-#include <stdexcept>
 
 #include "gtest/gtest.h"
 
 #include "SCC/config/scc_mode.h"
+#include "SCC/fixtures_common/enum.h"
 
 using namespace scc::config;
 using namespace testing;
 
+using UChar = unsigned char;
+
 TEST(SCCModeValueEnumTests, IsUnsignedCharTest) {
-  int N_0 = 0;
-  EXPECT_EQ((unsigned char) N_0, SCCMode::Value(N_0));
-
-  int N_neg1 = -1;
-  EXPECT_EQ((unsigned char) N_neg1, SCCMode::Value(N_neg1));
-
-  int N_50 = 50;
-  EXPECT_EQ((unsigned char) N_50, SCCMode::Value(N_50));
-
-  int N_128 = 128;
-  EXPECT_EQ((unsigned char) N_128, SCCMode::Value(N_128));
-
-  int N_256 = 256;
-  EXPECT_EQ((unsigned char) N_256, SCCMode::Value(N_256));
+  CastEnumTestBody<UChar, SCCMode::Value>(0);
+  CastEnumTestBody<UChar, SCCMode::Value>(-1);
+  CastEnumTestBody<UChar, SCCMode::Value>(50);
+  CastEnumTestBody<UChar, SCCMode::Value>(128);
+  CastEnumTestBody<UChar, SCCMode::Value>(256);
 }
 
 TEST(SCCModeCtorTests, DefaultValueTest) {
@@ -32,54 +24,38 @@ TEST(SCCModeCtorTests, DefaultValueTest) {
 }
 
 TEST(SCCModeCtorTests, ValueTest) {
-  EXPECT_EQ(SCCMode::kDaemon, (SCCMode::Value) SCCMode(SCCMode::kDaemon));
-  EXPECT_EQ(SCCMode::kInteractive, (SCCMode::Value) SCCMode(SCCMode::Value(0)));
+  CastWrapperToValueTestBody<SCCMode, SCCMode::Value>(SCCMode::kDaemon);
+  CastWrapperToValueTestBody<SCCMode, SCCMode::Value>(SCCMode::kInteractive);
 }
 
 TEST(SCCModeCtorTests, InvalidValueTest) {
-  EXPECT_THROW(SCCMode(SCCMode::Value(-1)), std::invalid_argument);
-  EXPECT_THROW(SCCMode(SCCMode::Value(10)), std::invalid_argument);
-}
-
-TEST(SCCModeCtorTests, StringValueTest) {
-  SCCMode interactive(kMode_Interactive);
-  EXPECT_EQ(SCCMode::kInteractive, (SCCMode::Value) interactive);
-
-  SCCMode daemon(kMode_Daemon);
-  EXPECT_EQ(SCCMode::kDaemon, (SCCMode::Value) daemon);
-
-  SCCMode mixed_case_daemon("DaeMON");
-  EXPECT_EQ(SCCMode::kDaemon, (SCCMode::Value) mixed_case_daemon);
+  CreateWithInvalidArgumentTestBody<SCCMode, SCCMode::Value>(-1);
+  CreateWithInvalidArgumentTestBody<SCCMode, SCCMode::Value>(10);
 }
 
 TEST(SCCModeCtorTests, InvalidStringValueTest) {
-  EXPECT_THROW(SCCMode("invalid mode"), std::invalid_argument);
-  EXPECT_THROW(SCCMode("dakmon"), std::invalid_argument);
+  CreateWithInvalidArgumentTestBody<SCCMode, SCCMode::Value>("invalid mode");
+  CreateWithInvalidArgumentTestBody<SCCMode, SCCMode::Value>("dakmon");
+}
+
+TEST(SCCModeCtorTests, StringValueTest) {
+  CreateFromStringTestBody<SCCMode>(kMode_Interactive, SCCMode::kInteractive);
+  CreateFromStringTestBody<SCCMode>(kMode_Daemon, SCCMode::kDaemon);
+}
+
+TEST(DataTypeCtorTests, MixedCaseStringTest) {
+  CreateFromStringTestBody<SCCMode>("DaeMON", SCCMode::kDaemon);
+  CreateFromStringTestBody<SCCMode>("interACTIVE", SCCMode::kInteractive);
 }
 
 TEST(SCCModeoStringTests, ToStringTest) {
-  EXPECT_EQ(kMode_Daemon, SCCMode(SCCMode::kDaemon).ToString());
-  EXPECT_EQ(kMode_Interactive, SCCMode(SCCMode::kInteractive).ToString());
-}
-
-TEST(SCCModeCastTests, CastToValueTest) {
-  SCCMode interactive(SCCMode::kInteractive);
-  auto interactive_val = (SCCMode::Value) interactive;
-  EXPECT_EQ(SCCMode::kInteractive, interactive_val);
-
-  SCCMode daemon(SCCMode::kDaemon);
-  auto daemon_val = (SCCMode::Value) daemon;
-  EXPECT_EQ(SCCMode::kDaemon, daemon_val);
+  ToStringTestBody<SCCMode>(SCCMode::kDaemon, kMode_Daemon);
+  ToStringTestBody<SCCMode>(SCCMode::kInteractive, kMode_Interactive);
 }
 
 TEST(SCCModeOperatorsTests, OutputTest) {
-  std::ostringstream oss_interactive;
-  oss_interactive << SCCMode(SCCMode::kInteractive);
-  EXPECT_EQ(kMode_Interactive, oss_interactive.str());
-
-  std::ostringstream oss_daemon;
-  oss_daemon << SCCMode(SCCMode::kDaemon);
-  EXPECT_EQ(kMode_Daemon, oss_daemon.str());
+  OutputTestBody<SCCMode, SCCMode::Value>(SCCMode::kInteractive, kMode_Interactive);
+  OutputTestBody<SCCMode, SCCMode::Value>(SCCMode::kDaemon, kMode_Daemon);
 }
 
 TEST(SCCModeOperatorsTests, CompareTwoEqualModesTest) {

--- a/test/fixtures/include/SCC/fixtures_common/enum.h
+++ b/test/fixtures/include/SCC/fixtures_common/enum.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <type_traits>
+#include <string>
+#include <sstream>
+
+template<typename EnumBaseType, typename EnumT, typename = std::enable_if_t<std::is_enum_v<EnumT>>>
+void CastEnumTestBody(int n) {
+  EXPECT_EQ(static_cast<EnumBaseType>(n), EnumT(n));
+}
+
+template<typename EnumWrapperT, typename EnumT, typename = std::enable_if_t<std::is_enum_v<EnumT>>>
+void CastWrapperToValueTestBody(EnumWrapperT element) {
+  EXPECT_EQ(element, static_cast<EnumT>(EnumWrapperT(element)));
+}
+
+template<typename EnumWrapperT, typename EnumT, typename = std::enable_if_t<std::is_enum_v<EnumT>>>
+void CreateWithInvalidArgumentTestBody(int v) {
+  EXPECT_THROW(EnumWrapperT(EnumT(v)), std::invalid_argument);
+}
+
+template<typename EnumWrapperT, typename EnumT, typename = std::enable_if_t<std::is_enum_v<EnumT>>>
+void CreateWithInvalidArgumentTestBody(const std::string& v) {
+  EXPECT_THROW(EnumWrapperT element(v), std::invalid_argument);
+}
+
+template<typename EnumWrapperT>
+void CreateFromStringTestBody(const std::string_view& str, EnumWrapperT expected) {
+  EnumWrapperT element(str);
+  EXPECT_EQ(expected, element);
+}
+
+template<typename EnumWrapperT>
+void ToStringTestBody(EnumWrapperT element, const std::string_view& expected) {
+  EXPECT_EQ(expected, element.ToString());
+}
+
+template<typename EnumWrapperT, typename EnumT, typename = std::enable_if_t<std::is_enum_v<EnumT>>>
+void OutputTestBody(EnumT element, const std::string_view& expected) {
+  std::ostringstream oss;
+  oss << EnumWrapperT(element);
+  EXPECT_EQ(expected, oss.str());
+}

--- a/test/fixtures/include/SCC/fixtures_common/enum.h
+++ b/test/fixtures/include/SCC/fixtures_common/enum.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <type_traits>
+#include <stdexcept>
 #include <string>
 #include <sstream>
 

--- a/test/lexer/symbol_types_test.cpp
+++ b/test/lexer/symbol_types_test.cpp
@@ -56,7 +56,7 @@ TEST(SymbolTypeCtorTests, StringValueTest) {
   CreateFromStringTestBody<SymbolType>(kSYMT_NullTerminator, SymbolType::kNullTerminator);
 }
 
-TEST(DataTypeCtorTests, MixedCaseStringTest) {
+TEST(SymbolTypeCtorTests, MixedCaseStringTest) {
   CreateFromStringTestBody<SymbolType>("unKNOWN", SymbolType::kUnknown);
   CreateFromStringTestBody<SymbolType>("SpAcE", SymbolType::kSpace);
   CreateFromStringTestBody<SymbolType>("DIGIT", SymbolType::kDigit);
@@ -68,7 +68,7 @@ TEST(DataTypeCtorTests, MixedCaseStringTest) {
   CreateFromStringTestBody<SymbolType>("NULl", SymbolType::kNullTerminator);
 }
 
-TEST(SymbolTypeoStringTests, ToStringTest) {
+TEST(SymbolTypeStringTests, ToStringTest) {
   ToStringTestBody<SymbolType>(SymbolType::kUnknown, kSYMT_Unknown);
   ToStringTestBody<SymbolType>(SymbolType::kSpace, kSYMT_Space);
   ToStringTestBody<SymbolType>(SymbolType::kDigit, kSYMT_Digit);

--- a/test/lexer/symbol_types_test.cpp
+++ b/test/lexer/symbol_types_test.cpp
@@ -1,28 +1,21 @@
-#include <sstream>
-#include <stdexcept>
+#include <compare>
 
 #include "gtest/gtest.h"
 
+#include "SCC/fixtures_common/enum.h"
 #include "SCC/lexer/symbol_types.h"
 
 using namespace scc::lexer;
 using namespace testing;
 
+using UChar = unsigned char;
+
 TEST(SymbolTypeValueEnumTests, IsUnsignedCharTest) {
-  int N_0 = 0;
-  EXPECT_EQ((unsigned char) N_0, SymbolType::Value(N_0));
-
-  int N_neg1 = -1;
-  EXPECT_EQ((unsigned char) N_neg1, SymbolType::Value(N_neg1));
-
-  int N_50 = 50;
-  EXPECT_EQ((unsigned char) N_50, SymbolType::Value(N_50));
-
-  int N_128 = 128;
-  EXPECT_EQ((unsigned char) N_128, SymbolType::Value(N_128));
-
-  int N_256 = 256;
-  EXPECT_EQ((unsigned char) N_256, SymbolType::Value(N_256));
+  CastEnumTestBody<UChar, SymbolType::Value>(0);
+  CastEnumTestBody<UChar, SymbolType::Value>(-1);
+  CastEnumTestBody<UChar, SymbolType::Value>(50);
+  CastEnumTestBody<UChar, SymbolType::Value>(128);
+  CastEnumTestBody<UChar, SymbolType::Value>(256);
 }
 
 TEST(SymbolTypeCtorTests, DefaultValueTest) {
@@ -31,71 +24,67 @@ TEST(SymbolTypeCtorTests, DefaultValueTest) {
 }
 
 TEST(SymbolTypeCtorTests, ValueTest) {
-  EXPECT_EQ(SymbolType::kUnknown, (SymbolType::Value) SymbolType(SymbolType::kUnknown));
-  EXPECT_EQ(SymbolType::kSpace, (SymbolType::Value) SymbolType(SymbolType::kSpace));
-  EXPECT_EQ(SymbolType::kAlpha, (SymbolType::Value) SymbolType(SymbolType::kAlpha));
-  EXPECT_EQ(SymbolType::kBracket, (SymbolType::Value) SymbolType(SymbolType::kBracket));
-  EXPECT_EQ(SymbolType::kEOF, (SymbolType::Value) SymbolType(SymbolType::kEOF));
+  CastWrapperToValueTestBody<SymbolType, SymbolType::Value>(SymbolType::kUnknown);
+  CastWrapperToValueTestBody<SymbolType, SymbolType::Value>(SymbolType::kSpace);
+  CastWrapperToValueTestBody<SymbolType, SymbolType::Value>(SymbolType::kAlpha);
+  CastWrapperToValueTestBody<SymbolType, SymbolType::Value>(SymbolType::kBracket);
+  CastWrapperToValueTestBody<SymbolType, SymbolType::Value>(SymbolType::kEOF);
 }
 
 TEST(SymbolTypeCtorTests, InvalidValueTest) {
-  EXPECT_THROW(SymbolType(SymbolType::Value(-1)), std::invalid_argument);
-  EXPECT_THROW(SymbolType(SymbolType::Value(100)), std::invalid_argument);
-}
-
-TEST(SymbolTypeCtorTests, StringValueTest) {
-  SymbolType space(kSYMT_Space);
-  EXPECT_EQ(SymbolType::kSpace, (SymbolType::Value) space);
-
-  SymbolType operator_(kSYMT_Operator);
-  EXPECT_EQ(SymbolType::kOperator, (SymbolType::Value) operator_);
-
-  SymbolType mixed_case_bracket("brAcKEt");
-  EXPECT_EQ(SymbolType::kBracket, (SymbolType::Value) mixed_case_bracket);
+  CreateWithInvalidArgumentTestBody<SymbolType, SymbolType::Value>(-1);
+  CreateWithInvalidArgumentTestBody<SymbolType, SymbolType::Value>(100);
 }
 
 TEST(SymbolTypeCtorTests, InvalidStringValueTest) {
-  EXPECT_THROW(SymbolType("invalid value"), std::invalid_argument);
-  EXPECT_THROW(SymbolType("asd9g8"), std::invalid_argument);
-  EXPECT_THROW(SymbolType("br@cket"), std::invalid_argument);
-  EXPECT_THROW(SymbolType("abcd"), std::invalid_argument);
-  EXPECT_THROW(SymbolType("punctuatio"), std::invalid_argument);
+  CreateWithInvalidArgumentTestBody<SymbolType, SymbolType::Value>("invalid value");
+  CreateWithInvalidArgumentTestBody<SymbolType, SymbolType::Value>("asd9g8");
+  CreateWithInvalidArgumentTestBody<SymbolType, SymbolType::Value>("br@cket");
+  CreateWithInvalidArgumentTestBody<SymbolType, SymbolType::Value>("abcd");
+  CreateWithInvalidArgumentTestBody<SymbolType, SymbolType::Value>("punctuatio");
+}
+
+TEST(SymbolTypeCtorTests, StringValueTest) {
+  CreateFromStringTestBody<SymbolType>(kSYMT_Unknown, SymbolType::kUnknown);
+  CreateFromStringTestBody<SymbolType>(kSYMT_Space, SymbolType::kSpace);
+  CreateFromStringTestBody<SymbolType>(kSYMT_Digit, SymbolType::kDigit);
+  CreateFromStringTestBody<SymbolType>(kSYMT_Alpha, SymbolType::kAlpha);
+  CreateFromStringTestBody<SymbolType>(kSYMT_Operator, SymbolType::kOperator);
+  CreateFromStringTestBody<SymbolType>(kSYMT_Bracket, SymbolType::kBracket);
+  CreateFromStringTestBody<SymbolType>(kSYMT_Punctuation, SymbolType::kPunctuation);
+  CreateFromStringTestBody<SymbolType>(kSYMT_EOF, SymbolType::kEOF);
+  CreateFromStringTestBody<SymbolType>(kSYMT_NullTerminator, SymbolType::kNullTerminator);
+}
+
+TEST(DataTypeCtorTests, MixedCaseStringTest) {
+  CreateFromStringTestBody<SymbolType>("unKNOWN", SymbolType::kUnknown);
+  CreateFromStringTestBody<SymbolType>("SpAcE", SymbolType::kSpace);
+  CreateFromStringTestBody<SymbolType>("DIGIT", SymbolType::kDigit);
+  CreateFromStringTestBody<SymbolType>("alpha", SymbolType::kAlpha);
+  CreateFromStringTestBody<SymbolType>("OPERator", SymbolType::kOperator);
+  CreateFromStringTestBody<SymbolType>("brAcKEt", SymbolType::kBracket);
+  CreateFromStringTestBody<SymbolType>("PUNCTuation", SymbolType::kPunctuation);
+  CreateFromStringTestBody<SymbolType>("Eof", SymbolType::kEOF);
+  CreateFromStringTestBody<SymbolType>("NULl", SymbolType::kNullTerminator);
 }
 
 TEST(SymbolTypeoStringTests, ToStringTest) {
-  EXPECT_EQ(kSYMT_Unknown, SymbolType(SymbolType::kUnknown).ToString());
-  EXPECT_EQ(kSYMT_Alpha, SymbolType(SymbolType::kAlpha).ToString());
-  EXPECT_EQ(kSYMT_Bracket, SymbolType(SymbolType::kBracket).ToString());
-  EXPECT_EQ(kSYMT_NullTerminator, SymbolType(SymbolType::kNullTerminator).ToString());
-  EXPECT_EQ(kSYMT_EOF, SymbolType(SymbolType::kEOF).ToString());
-}
-
-TEST(SymbolTypeCastTests, CastToValueTest) {
-  SymbolType eof(SymbolType::kEOF);
-  auto eof_val = (SymbolType::Value) eof;
-  EXPECT_EQ(SymbolType::kEOF, eof_val);
-
-  SymbolType operator_(SymbolType::kOperator);
-  auto operator_val = (SymbolType::Value) operator_;
-  EXPECT_EQ(SymbolType::kOperator, operator_val);
+  ToStringTestBody<SymbolType>(SymbolType::kUnknown, kSYMT_Unknown);
+  ToStringTestBody<SymbolType>(SymbolType::kSpace, kSYMT_Space);
+  ToStringTestBody<SymbolType>(SymbolType::kDigit, kSYMT_Digit);
+  ToStringTestBody<SymbolType>(SymbolType::kAlpha, kSYMT_Alpha);
+  ToStringTestBody<SymbolType>(SymbolType::kOperator, kSYMT_Operator);
+  ToStringTestBody<SymbolType>(SymbolType::kBracket, kSYMT_Bracket);
+  ToStringTestBody<SymbolType>(SymbolType::kPunctuation, kSYMT_Punctuation);
+  ToStringTestBody<SymbolType>(SymbolType::kEOF, kSYMT_EOF);
+  ToStringTestBody<SymbolType>(SymbolType::kNullTerminator, kSYMT_NullTerminator);
 }
 
 TEST(SymbolTypeOperatorsTests, OutputTest) {
-  std::ostringstream oss_unknown;
-  oss_unknown << SymbolType(SymbolType::kUnknown);
-  EXPECT_EQ(kSYMT_Unknown, oss_unknown.str());
-
-  std::ostringstream oss_digit;
-  oss_digit << SymbolType(SymbolType::kDigit);
-  EXPECT_EQ(kSYMT_Digit, oss_digit.str());
-
-  std::ostringstream oss_space;
-  oss_space << SymbolType(SymbolType::kSpace);
-  EXPECT_EQ(kSYMT_Space, oss_space.str());
-
-  std::ostringstream oss_alpha;
-  oss_alpha << SymbolType(SymbolType::kAlpha);
-  EXPECT_EQ(kSYMT_Alpha, oss_alpha.str());
+  OutputTestBody<SymbolType, SymbolType::Value>(SymbolType::kUnknown, kSYMT_Unknown);
+  OutputTestBody<SymbolType, SymbolType::Value>(SymbolType::kDigit, kSYMT_Digit);
+  OutputTestBody<SymbolType, SymbolType::Value>(SymbolType::kSpace, kSYMT_Space);
+  OutputTestBody<SymbolType, SymbolType::Value>(SymbolType::kAlpha, kSYMT_Alpha);
 }
 
 TEST(SymbolTypeOperatorsTests, CompareTwoEqualTypesTest) {

--- a/test/translator/cypher/graph/CMakeLists.txt
+++ b/test/translator/cypher/graph/CMakeLists.txt
@@ -2,4 +2,5 @@ scc_test(scc_test_translator_cypher_graph
         constraint_types_serialization_test.cpp
         constraint_types_test.cpp
         property_types_serialization_test.cpp
+        property_types_test.cpp
 )

--- a/test/translator/cypher/graph/CMakeLists.txt
+++ b/test/translator/cypher/graph/CMakeLists.txt
@@ -1,4 +1,5 @@
 scc_test(scc_test_translator_cypher_graph
         constraint_types_serialization_test.cpp
+        constraint_types_test.cpp
         property_types_serialization_test.cpp
 )

--- a/test/translator/cypher/graph/constraint_types_test.cpp
+++ b/test/translator/cypher/graph/constraint_types_test.cpp
@@ -1,0 +1,116 @@
+#include <compare>
+
+#include "gtest/gtest.h"
+
+#include "SCC/fixtures_common/enum.h"
+#include "SCC/translator/cypher/graph/constraint_types.h"
+
+using namespace scc::translator::cypher;
+using namespace testing;
+
+using UChar = unsigned char;
+
+TEST(ConstraintTypeValueEnumTests, IsUnsignedCharTest) {
+  CastEnumTestBody<UChar, ConstraintType::Value>(0);
+  CastEnumTestBody<UChar, ConstraintType::Value>(-1);
+  CastEnumTestBody<UChar, ConstraintType::Value>(50);
+  CastEnumTestBody<UChar, ConstraintType::Value>(128);
+  CastEnumTestBody<UChar, ConstraintType::Value>(256);
+}
+
+TEST(ConstraintTypeCtorTests, DefaultValueTest) {
+  ConstraintType type;
+  EXPECT_EQ(ConstraintType::kNone, (ConstraintType::Value) type);
+}
+
+TEST(ConstraintTypeCtorTests, ValueTest) {
+  CastWrapperToValueTestBody<ConstraintType, ConstraintType::Value>(ConstraintType::kNone);
+  CastWrapperToValueTestBody<ConstraintType, ConstraintType::Value>(ConstraintType::kUniqueness);
+  CastWrapperToValueTestBody<ConstraintType, ConstraintType::Value>(ConstraintType::kExistence);
+}
+
+TEST(ConstraintTypeCtorTests, InvalidValueTest) {
+  CreateWithInvalidArgumentTestBody<ConstraintType, ConstraintType::Value>(-1);
+  CreateWithInvalidArgumentTestBody<ConstraintType, ConstraintType::Value>(3);
+}
+
+TEST(ConstraintTypeCtorTests, InvalidStringValueTest) {
+  CreateWithInvalidArgumentTestBody<ConstraintType, ConstraintType::Value>("invalid");
+  CreateWithInvalidArgumentTestBody<ConstraintType, ConstraintType::Value>("n0ne");
+  CreateWithInvalidArgumentTestBody<ConstraintType, ConstraintType::Value>("unqie");
+}
+
+TEST(ConstraintTypeCtorTests, StringValueTest) {
+  CreateFromStringTestBody<ConstraintType>(kCT_None, ConstraintType::kNone);
+  CreateFromStringTestBody<ConstraintType>(kCT_Uniqueness, ConstraintType::kUniqueness);
+  CreateFromStringTestBody<ConstraintType>(kCT_Existence, ConstraintType::kExistence);
+}
+
+TEST(ConstraintTypeCtorTests, MixedCaseStringTest) {
+  CreateFromStringTestBody<ConstraintType>("NONe", ConstraintType::kNone);
+  CreateFromStringTestBody<ConstraintType>("UnIqUe", ConstraintType::kUniqueness);
+  CreateFromStringTestBody<ConstraintType>("not NULL", ConstraintType::kExistence);
+}
+
+TEST(ConstraintTypeoStringTests, ToStringTest) {
+  ToStringTestBody<ConstraintType>(ConstraintType::kNone, kCT_None);
+  ToStringTestBody<ConstraintType>(ConstraintType::kUniqueness, kCT_Uniqueness);
+  ToStringTestBody<ConstraintType>(ConstraintType::kExistence, kCT_Existence);
+}
+
+TEST(ConstraintTypeOperatorsTests, OutputTest) {
+  OutputTestBody<ConstraintType, ConstraintType::Value>(ConstraintType::kNone, kCT_None);
+  OutputTestBody<ConstraintType, ConstraintType::Value>(ConstraintType::kUniqueness, kCT_Uniqueness);
+  OutputTestBody<ConstraintType, ConstraintType::Value>(ConstraintType::kExistence, kCT_Existence);
+}
+
+TEST(ConstraintTypeOperatorsTests, CompareTwoEqualTypesTest) {
+  ConstraintType first(ConstraintType::kUniqueness);
+  ConstraintType second(ConstraintType::kUniqueness);
+
+  EXPECT_TRUE(first == second);
+  EXPECT_TRUE(first <= second);
+  EXPECT_TRUE(first >= second);
+  EXPECT_FALSE(first != second);
+  EXPECT_FALSE(first < second);
+  EXPECT_FALSE(first > second);
+  EXPECT_EQ(std::partial_ordering::equivalent, first <=> second);
+}
+
+TEST(ConstraintTypeOperatorsTests, CompareTwoDifferentTypesTest) {
+  ConstraintType first(ConstraintType::kUniqueness);
+  ConstraintType second(ConstraintType::kExistence);
+
+  EXPECT_TRUE(first != second);
+  EXPECT_TRUE(first <= second);
+  EXPECT_TRUE(first < second);
+  EXPECT_FALSE(first == second);
+  EXPECT_FALSE(first >= second);
+  EXPECT_FALSE(first > second);
+  EXPECT_EQ(std::partial_ordering::less, first <=> second);
+  EXPECT_EQ(std::partial_ordering::greater, second <=> first);
+}
+
+TEST(ConstraintTypeOperatorsTests, CompareWithEqualValueTest) {
+  ConstraintType type(ConstraintType::kExistence);
+  ConstraintType::Value value = ConstraintType::kExistence;
+
+  EXPECT_TRUE(type == value);
+  EXPECT_TRUE(type <= value);
+  EXPECT_TRUE(type >= value);
+  EXPECT_FALSE(type != value);
+  EXPECT_FALSE(type < value);
+  EXPECT_FALSE(type > value);
+}
+
+TEST(ConstraintTypeOperatorsTests, CompareWithDifferentValueTest) {
+  ConstraintType type(ConstraintType::kUniqueness);
+  ConstraintType::Value value = ConstraintType::kExistence;
+
+  EXPECT_TRUE(type != value);
+  EXPECT_TRUE(type <= value);
+  EXPECT_TRUE(type < value);
+  EXPECT_FALSE(type == value);
+  EXPECT_FALSE(type >= value);
+  EXPECT_FALSE(type > value);
+}

--- a/test/translator/cypher/graph/constraint_types_test.cpp
+++ b/test/translator/cypher/graph/constraint_types_test.cpp
@@ -52,7 +52,7 @@ TEST(ConstraintTypeCtorTests, MixedCaseStringTest) {
   CreateFromStringTestBody<ConstraintType>("not NULL", ConstraintType::kExistence);
 }
 
-TEST(ConstraintTypeoStringTests, ToStringTest) {
+TEST(ConstraintTypeStringTests, ToStringTest) {
   ToStringTestBody<ConstraintType>(ConstraintType::kNone, kCT_None);
   ToStringTestBody<ConstraintType>(ConstraintType::kUniqueness, kCT_Uniqueness);
   ToStringTestBody<ConstraintType>(ConstraintType::kExistence, kCT_Existence);

--- a/test/translator/cypher/graph/property_types_test.cpp
+++ b/test/translator/cypher/graph/property_types_test.cpp
@@ -58,7 +58,7 @@ TEST(PropertyTypeCtorTests, MixedCaseStringTest) {
   CreateFromStringTestBody<PropertyType>("null", PropertyType::kNull);
 }
 
-TEST(PropertyTypeoStringTests, ToStringTest) {
+TEST(PropertyTypeStringTests, ToStringTest) {
   ToStringTestBody<PropertyType>(PropertyType::kUnknown, kPT_Unknown);
   ToStringTestBody<PropertyType>(PropertyType::kBoolean, kPT_Boolean);
   ToStringTestBody<PropertyType>(PropertyType::kFloat, kPT_Float);

--- a/test/translator/cypher/graph/property_types_test.cpp
+++ b/test/translator/cypher/graph/property_types_test.cpp
@@ -1,0 +1,125 @@
+#include <compare>
+
+#include "gtest/gtest.h"
+
+#include "SCC/fixtures_common/enum.h"
+#include "SCC/translator/cypher/graph/property_types.h"
+
+using namespace scc::translator::cypher;
+using namespace testing;
+
+using UChar = unsigned char;
+
+TEST(PropertyTypeValueEnumTests, IsUnsignedCharTest) {
+  CastEnumTestBody<UChar, PropertyType::Value>(0);
+  CastEnumTestBody<UChar, PropertyType::Value>(-1);
+  CastEnumTestBody<UChar, PropertyType::Value>(50);
+  CastEnumTestBody<UChar, PropertyType::Value>(128);
+  CastEnumTestBody<UChar, PropertyType::Value>(256);
+}
+
+TEST(PropertyTypeCtorTests, DefaultValueTest) {
+  PropertyType type;
+  EXPECT_EQ(PropertyType::kUnknown, (PropertyType::Value) type);
+}
+
+TEST(PropertyTypeCtorTests, ValueTest) {
+  CastWrapperToValueTestBody<PropertyType, PropertyType::Value>(PropertyType::kUnknown);
+  CastWrapperToValueTestBody<PropertyType, PropertyType::Value>(PropertyType::kBoolean);
+  CastWrapperToValueTestBody<PropertyType, PropertyType::Value>(PropertyType::kInteger);
+}
+
+TEST(PropertyTypeCtorTests, InvalidValueTest) {
+  CreateWithInvalidArgumentTestBody<PropertyType, PropertyType::Value>(-1);
+  CreateWithInvalidArgumentTestBody<PropertyType, PropertyType::Value>(6);
+}
+
+TEST(PropertyTypeCtorTests, InvalidStringValueTest) {
+  CreateWithInvalidArgumentTestBody<PropertyType, PropertyType::Value>("nil");
+  CreateWithInvalidArgumentTestBody<PropertyType, PropertyType::Value>("int");
+  CreateWithInvalidArgumentTestBody<PropertyType, PropertyType::Value>("flot");
+}
+
+TEST(PropertyTypeCtorTests, StringValueTest) {
+  CreateFromStringTestBody<PropertyType>(kPT_Unknown, PropertyType::kUnknown);
+  CreateFromStringTestBody<PropertyType>(kPT_Boolean, PropertyType::kBoolean);
+  CreateFromStringTestBody<PropertyType>(kPT_Float, PropertyType::kFloat);
+  CreateFromStringTestBody<PropertyType>(kPT_Integer, PropertyType::kInteger);
+  CreateFromStringTestBody<PropertyType>(kPT_String, PropertyType::kString);
+  CreateFromStringTestBody<PropertyType>(kPT_Null, PropertyType::kNull);
+}
+
+TEST(PropertyTypeCtorTests, MixedCaseStringTest) {
+  CreateFromStringTestBody<PropertyType>("unknown", PropertyType::kUnknown);
+  CreateFromStringTestBody<PropertyType>("bOOleAN", PropertyType::kBoolean);
+  CreateFromStringTestBody<PropertyType>("FLOAT", PropertyType::kFloat);
+  CreateFromStringTestBody<PropertyType>("InteGER", PropertyType::kInteger);
+  CreateFromStringTestBody<PropertyType>("STRing", PropertyType::kString);
+  CreateFromStringTestBody<PropertyType>("null", PropertyType::kNull);
+}
+
+TEST(PropertyTypeoStringTests, ToStringTest) {
+  ToStringTestBody<PropertyType>(PropertyType::kUnknown, kPT_Unknown);
+  ToStringTestBody<PropertyType>(PropertyType::kBoolean, kPT_Boolean);
+  ToStringTestBody<PropertyType>(PropertyType::kFloat, kPT_Float);
+  ToStringTestBody<PropertyType>(PropertyType::kInteger, kPT_Integer);
+  ToStringTestBody<PropertyType>(PropertyType::kString, kPT_String);
+  ToStringTestBody<PropertyType>(PropertyType::kNull, kPT_Null);
+}
+
+TEST(PropertyTypeOperatorsTests, OutputTest) {
+  OutputTestBody<PropertyType, PropertyType::Value>(PropertyType::kUnknown, kPT_Unknown);
+  OutputTestBody<PropertyType, PropertyType::Value>(PropertyType::kFloat, kPT_Float);
+  OutputTestBody<PropertyType, PropertyType::Value>(PropertyType::kNull, kPT_Null);
+}
+
+TEST(PropertyTypeOperatorsTests, CompareTwoEqualTypesTest) {
+  PropertyType first(PropertyType::kString);
+  PropertyType second(PropertyType::kString);
+
+  EXPECT_TRUE(first == second);
+  EXPECT_TRUE(first <= second);
+  EXPECT_TRUE(first >= second);
+  EXPECT_FALSE(first != second);
+  EXPECT_FALSE(first < second);
+  EXPECT_FALSE(first > second);
+  EXPECT_EQ(std::partial_ordering::equivalent, first <=> second);
+}
+
+TEST(PropertyTypeOperatorsTests, CompareTwoDifferentTypesTest) {
+  PropertyType first(PropertyType::kFloat);
+  PropertyType second(PropertyType::kNull);
+
+  EXPECT_TRUE(first != second);
+  EXPECT_TRUE(first <= second);
+  EXPECT_TRUE(first < second);
+  EXPECT_FALSE(first == second);
+  EXPECT_FALSE(first >= second);
+  EXPECT_FALSE(first > second);
+  EXPECT_EQ(std::partial_ordering::less, first <=> second);
+  EXPECT_EQ(std::partial_ordering::greater, second <=> first);
+}
+
+TEST(PropertyTypeOperatorsTests, CompareWithEqualValueTest) {
+  PropertyType type(PropertyType::kBoolean);
+  PropertyType::Value value = PropertyType::kBoolean;
+
+  EXPECT_TRUE(type == value);
+  EXPECT_TRUE(type <= value);
+  EXPECT_TRUE(type >= value);
+  EXPECT_FALSE(type != value);
+  EXPECT_FALSE(type < value);
+  EXPECT_FALSE(type > value);
+}
+
+TEST(PropertyTypeOperatorsTests, CompareWithDifferentValueTest) {
+  PropertyType type(PropertyType::kUnknown);
+  PropertyType::Value value = PropertyType::kNull;
+
+  EXPECT_TRUE(type != value);
+  EXPECT_TRUE(type <= value);
+  EXPECT_TRUE(type < value);
+  EXPECT_FALSE(type == value);
+  EXPECT_FALSE(type >= value);
+  EXPECT_FALSE(type > value);
+}


### PR DESCRIPTION
Closes #61 

- Added new fixtures for testing enums, which simplifies unit testing enum wrappers;
- Refactored all enum tests with the new fixtures;
- Added missed unit tests for `PropertyType` and `ConstraintType` enum wrappers.